### PR TITLE
[new] brewerydb.coffee

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -1,2 +1,3 @@
 [
+  "brewerydb.coffee"
 ]


### PR DESCRIPTION
obtiene información sobre :beer: de la api de brewerydb. necesita
API-KEY (entregada a :hector: para que la agregue a heroku)