### PR TITLE
feat(tusecreto): add optional channel param

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "hubot-rules": "^0.1.1",
     "hubot-scripts": "^2.17.2",
     "hubot-shipit": "^0.2.0",
-    "hubot-slack": "^4.0.3",
+    "hubot-slack": "^4.1.0",
     "hubot-soon": "^1.0.0",
     "hubot-tweets": "devschile/hubot-tweets",
     "hubot-vimeo": "^1.0.1",

--- a/scripts/tusecreto.js
+++ b/scripts/tusecreto.js
@@ -1,15 +1,16 @@
 // Description:
 //   Tu secreto queda entre tú y :huemul:
-//   Dile un secreto a @huemul por DM y éste lo anunciará en el canal #random sin mencionarte.
+//   Dile un secreto a @huemul por DM y éste lo anunciará en el canal seleccionado o #random sin mencionarte.
 //
 // Dependencies:
 //   None
 //
 // Configuration:
-//   None
+//   HUBOT_MYSECRET_ALLOWED_CHANNELS: Lista de canales separados por comas.
+//                                    Ej: '#random,#pegas,#otrocanal'
 //
 // Commands:
-//   hubot mi secreto <secreto>
+//   hubot mi secreto [canal] <secreto>
 //
 // Author:
 //   @jorgeepunan
@@ -17,18 +18,40 @@
 module.exports = function(robot) {
 	return robot.respond(/mi secreto (.*)/i, function(msg) {
 		var secreto = msg.match[1];
+		var channel = '#random';
+		var allowedChannels = process.env.HUBOT_MYSECRET_ALLOWED_CHANNELS || '#random';
+		var secretoArr = secreto.split(' ');
 
-		var words = ['@here', '@channel', '@group', '@everyone'];
-    var randomChannel = robot.adapter.client.rtm.dataStore.getChannelByName('#random')
-    if (!randomChannel) return;
+		allowedChannels = allowedChannels.split(',');
 
-		for (var i = 0; i < words.length; i++) {
-			if (secreto.indexOf(words[i]) !== -1) {
-				return robot.messageRoom(randomChannel.id, "El tonto de " + msg.message.user.name + " trató de usar @");
+		if (allowedChannels.indexOf('#' + secretoArr[0]) !== -1) {
+			channel = '#' + secretoArr.shift();
+			secreto = secretoArr.join(' ');
+		}
+
+		if (secreto.length === 0) {
+			return robot.messageRoom(msg.message.user.id, "¿Y el secreto?");
+		}
+
+		var slackChannel = robot.adapter.client.rtm.dataStore.getChannelByName(channel);
+
+		if (!slackChannel) {
+			return robot.messageRoom(msg.message.user.id, "No sé qué canal es ese.");
+		};
+
+		if (!slackChannel.is_member) {
+			return robot.messageRoom(msg.message.user.id, "No estoy en " + channel + ". :sadhuemul:");
+		};
+
+		var forbiddenWords = ['@here', '@channel', '@group', '@everyone'];
+
+		for (var i = 0; i < forbiddenWords.length; i++) {
+			if (secreto.indexOf(forbiddenWords[i]) !== -1) {
+				return robot.messageRoom(slackChannel.id, "El tonto de " + msg.message.user.name + " trató de usar @");
 			}
 		}
 
-		return robot.messageRoom(randomChannel.id, ":speak_no_evil: *Un secreto:* " + secreto);
+		return robot.messageRoom(slackChannel.id, ":speak_no_evil: *Un secreto:* " + secreto);
 	});
 };
 


### PR DESCRIPTION
Queda pendiente incluir un "#X no está entre los canales permitidos".  https://github.com/slackhq/hubot-slack/issues/361 hace algo complicado distinguir si el usuario está usando la palabra o está nombrando el canal.

Una vez que no se coma los # se podría incluir, aparte de poder usar regex directo en vez de usar el array para distinguir el canal.

resolves #68 