### PR TITLE
Se corrigió orden y formato de enlaces en script torrent

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -1,3 +1,0 @@
-[
-  "brewerydb.coffee"
-]

--- a/scripts/recetas.js
+++ b/scripts/recetas.js
@@ -37,11 +37,11 @@ module.exports = function(robot) {
 
         if(resNum.length) {
           var limiteResultados = (resultados.length > 4) ? 3 : resultados.length;
-          const resetas = resultados.slice(0, limiteResultados).map((v, i) => `${i + 1}: ${v}`).join('\n');
-          const more = resultados.length > limiteResultados ? `\n<${url}|Ver más resultados>` : '';
-          const text = `${resNum}\n${resetas}${more}`;
+          var resetas = resultados.slice(0, limiteResultados).map((v, i) => `${i + 1}: ${v}`).join('\n');
+          var more = resultados.length > limiteResultados ? `\n<${url}|Ver más resultados>` : '';
+          var text = `${resNum}\n${resetas}${more}`;
           if (robot.adapter.constructor.name === 'SlackBot') {
-            const options = {unfurl_links: false, as_user: true};
+            var options = {unfurl_links: false, as_user: true};
             robot.adapter.client.web.chat.postMessage(msg.message.room, text, options);
           } else {
             msg.send(text);

--- a/scripts/recetas.js
+++ b/scripts/recetas.js
@@ -39,7 +39,13 @@ module.exports = function(robot) {
           var limiteResultados = (resultados.length > 4) ? 3 : resultados.length;
           const resetas = resultados.slice(0, limiteResultados).map((v, i) => `${i + 1}: ${v}`).join('\n');
           const more = resultados.length > limiteResultados ? `\n<${url}|Ver más resultados>` : '';
-          msg.send(`${resNum}\n${resetas}${more}`);
+          const text = `${resNum}\n${resetas}${more}`;
+          if (robot.adapter.constructor.name === 'SlackBot') {
+            const options = {unfurl_links: false, as_user: true};
+            robot.adapter.client.web.chat.postMessage(msg.message.room, text, options);
+          } else {
+            msg.send(text);
+          }
         } else {
           msg.send('No se han encontrado resultados sobre '+ busqueda + '. Intenta con otro ingrediente.');
         }

--- a/scripts/torrent.js
+++ b/scripts/torrent.js
@@ -25,7 +25,7 @@ module.exports = function(robot) {
 
     cloudscraper.get(url, function(error, response, body) {
       if (error) {
-        console.log('Ocurrió un error :(');
+        robot.emit('error', error, response);
       } else {
         var $ = cheerio.load(body);
         var resultados = [];

--- a/scripts/torrent.js
+++ b/scripts/torrent.js
@@ -40,15 +40,15 @@ module.exports = function(robot) {
         if(resultados.length > 0) {
           var limiteResultados = (resultados.length > 4) ? 3 : resultados.length;
           var plural = resultados.length > 1 ? ['n','s'] : ['',''];
-          const resume = 'Se ha'+plural[0]+' encontrado '+ resultados.length + ' resultado'+plural[1];
-          const links = resultados
+          var resume = 'Se ha'+plural[0]+' encontrado '+ resultados.length + ' resultado'+plural[1];
+          var links = resultados
             .slice(0, limiteResultados)
             .map((result, index) => `${index + 1}: ${result}`)
             .join('\n');
-          const more = resultados.length > limiteResultados ? `\n<${url}|Ver más resultados>` : '';
-          const text = `${resume}\n${links}${more}`;
+          var more = resultados.length > limiteResultados ? `\n<${url}|Ver más resultados>` : '';
+          var text = `${resume}\n${links}${more}`;
           if (robot.adapter.constructor.name === 'SlackBot') {
-            const options = {unfurl_links: false, as_user: true};
+            var options = {unfurl_links: false, as_user: true};
             robot.adapter.client.web.chat.postMessage(msg.message.room, text, options);
           } else {
             msg.send(text);

--- a/scripts/torrent.js
+++ b/scripts/torrent.js
@@ -34,19 +34,24 @@ module.exports = function(robot) {
           var title = $(this).find('a').text();
           var link = $(this).find('a').attr('href');
 
-          resultados.push( title + ' | ' + domain + link );
+          resultados.push(`<${domain}${link}|${title}>`);
         });
 
         if(resultados.length > 0) {
           var limiteResultados = (resultados.length > 4) ? 3 : resultados.length;
           var plural = resultados.length > 1 ? ['n','s'] : ['',''];
-          msg.send('Se ha'+plural[0]+' encontrado '+ resultados.length + ' resultado'+plural[1]);
-          for (var i=0; i < limiteResultados; i++) {
-            var conteo = i + 1;
-            msg.send(conteo + ': ' + resultados[i]);
-          }
-          if(resultados.length > limiteResultados) {
-            msg.send('Otros resultados en: '+ url);
+          const resume = 'Se ha'+plural[0]+' encontrado '+ resultados.length + ' resultado'+plural[1];
+          const links = resultados
+            .slice(0, limiteResultados)
+            .map((result, index) => `${index + 1}: ${result}`)
+            .join('\n');
+          const more = resultados.length > limiteResultados ? `\n<${url}|Ver más resultados>` : '';
+          const text = `${resume}\n${links}${more}`;
+          if (robot.adapter.constructor.name === 'SlackBot') {
+            const options = {unfurl_links: false, as_user: true};
+            robot.adapter.client.web.chat.postMessage(msg.message.room, text, options);
+          } else {
+            msg.send(text);
           }
         } else {
           msg.send('No se han encontrado resultados sobre '+ busqueda);


### PR DESCRIPTION
- Se corrigió orden y formato de enlaces de resultados en torrent
- Se cambio `console.log` por `robot.emit` en torrent
- Se agrego `unfurl_links` en los resultados de receta y torrent
- Se elimino `hubot-scripts.json`. #132