### PR TITLE
feat(scripts): Se actualizo script hubot-memegeneration

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "hubot-insulter": "^1.0.2",
     "hubot-jobtitles": "0.0.2",
     "hubot-maps": "0.0.2",
-    "hubot-memegeneration": "^2.1.1",
+    "hubot-memegeneration": "^2.2.0",
     "hubot-minions": "0.0.2",
     "hubot-mrrobot": "0.0.1",
     "hubot-nic_chile": "0.0.2",


### PR DESCRIPTION
Ahora es posible usar texto arriba y abajo usando la sintaxis:
`huemul meme generate <template-name> <text1>|<text2>`

También es posible seguir usando la vieja sintaxis, para solo tener texto inferior:
`huemul meme generate <template-name> <text>`

Agradecimientos a :alvaro: :clap: 