### PR TITLE
bugfix: split `-` for URL's fixed

### DIFF
--- a/scripts/bip.coffee
+++ b/scripts/bip.coffee
@@ -25,7 +25,7 @@ module.exports = (robot) ->
       msg.send 'El identificador de tu BIP! son sólo números.'
       msg.send 'No sea leso, no se crea hacker. máZnáátèdííghó óèzíí'
     else
-      url = 'http://www.psep.cl/api/Bip.php?&numberBip=' + indicador
+      url = 'http://bip-servicio.herokuapp.com/api/v1/solicitudes.json?bip=' + indicador
 
       msg.http(url).get() (err, res, body) ->
         if err

--- a/scripts/cuantovale.js
+++ b/scripts/cuantovale.js
@@ -47,7 +47,7 @@ module.exports = function(robot) {
         if( $('.fa-bell').length ) {
           msg.send('Este sitio no existe. Intenta con otro.')
         } else {
-          msg.send(':monea: ' + $('title').text().trim().split('-')[0])
+          msg.send(':monea: ' + $('title').text().trim().split(' - ')[0])
         }
 
       });


### PR DESCRIPTION
test: `huemul cuantovale be-studios.com`

cata—