### PR TITLE
Permitir mas de un usuario por linea al asignar karma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "6"
+  - "7"
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,11 @@ node_js:
   - "7"
 notifications:
   email: false
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "bin/hubot",
   "scripts": {
     "start": "bin/hubot -a slack",
-    "dev": "bin/hubot"
+    "dev": "bin/hubot",
+    "test": "mocha --compilers coffee:coffee-script/register"
   },
   "engines": {
     "node": "6.9.x"
@@ -64,7 +65,7 @@
     "hubot-rules": "^0.1.1",
     "hubot-scripts": "^2.17.2",
     "hubot-shipit": "^0.2.0",
-    "hubot-slack": "^4.2.2",
+    "hubot-slack": "^4.3.1",
     "hubot-soon": "^1.0.0",
     "hubot-tweets": "devschile/hubot-tweets",
     "hubot-wikipedia-lang": "^1.0.1",
@@ -85,5 +86,11 @@
     "superheroes": "^1.0.0",
     "uuid": "^3.0.1",
     "yelp": "^1.0.2"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "coffee-script": "^1.12.4",
+    "hubot-test-helper": "^1.5.1",
+    "mocha": "^3.2.0"
   }
 }

--- a/scripts/karma.coffee
+++ b/scripts/karma.coffee
@@ -18,37 +18,16 @@ module.exports = (robot) ->
 
   hubotWebSite = "http://#{robot.name}.herokuapp.com/#{robot.name}"
 
-  robot.hear /@?(\S*)(\b(?:\+\+|--))(\s|$)/, (response) ->
-    thisUser = response.message.user
-    targetToken = response.match[1].trim()
-    return if not targetToken
+  robot.hear /@?(\S*)(\b\+\+|--)(\s|$)/g, (response) ->
+    tokens = response.match
+    return if not tokens
     return if not robot.adapter.client.rtm.dataStore.getChannelGroupOrDMById(response.envelope.room).is_channel
-    userForToken(targetToken, response)
-      .then (targetUser) ->
-        return if not targetUser
-        return response.send "Oe no po, el karma es pa otros no pa ti!" if thisUser.name is targetUser.name
-        op = response.match[2]
-        limit = canUpvote(thisUser, targetUser)
-        if Number.isFinite(limit)
-          response.send "¡No abuses! Intenta en " + limit + " minutos"
-          return
-        modifyingKarma = if op is "++" then 1 else -1
-        targetUser.karma += modifyingKarma
-        karmaLog = robot.brain.get('karmaLog') or []
-        karmaLog.push({
-          name: thisUser.name,
-          id: thisUser.id,
-          karma: modifyingKarma,
-          targetName: targetUser.name,
-          targetId: targetUser.id,
-          date: Date.now(),
-          msg: response.envelope.message.text
-        })
-        robot.brain.set 'karmaLog', karmaLog
-        robot.brain.save()
-        response.send "#{getCleanName(targetUser.name)} ahora tiene #{targetUser.karma} puntos de karma."
-    .catch (err) ->
-      console.log(err)
+
+    for token in tokens
+      opRegex = /\+\+|--/g;
+      userToken = token.trim().replace(opRegex,'')
+      op = token.match(opRegex)[0]
+      applyKarma(userToken, op, response)
 
   robot.hear /^karma(?:\s+@?(.*))?$/, (response) ->
     targetToken = response.match[1]?.trim()
@@ -127,6 +106,34 @@ module.exports = (robot) ->
       msg = "No hay detalles sobre el karma de #{req.params.user}"
     res.setHeader 'content-type', 'text/html'
     res.end msg
+
+  applyKarma = (userToken, op, response) ->
+    thisUser = response.message.user
+    userForToken(userToken, response)
+      .then (targetUser) ->
+        return if not targetUser
+        return response.send "Oe no po, el karma es pa otros no pa ti!" if thisUser.name is targetUser.name
+        limit = canUpvote(thisUser, targetUser)
+        if Number.isFinite(limit)
+          response.send "¡No abuses! Intenta en " + limit + " minutos"
+          return
+        modifyingKarma = if op is "++" then 1 else -1
+        targetUser.karma += modifyingKarma
+        karmaLog = robot.brain.get('karmaLog') or []
+        karmaLog.push({
+          name: thisUser.name,
+          id: thisUser.id,
+          karma: modifyingKarma,
+          targetName: targetUser.name,
+          targetId: targetUser.id,
+          date: Date.now(),
+          msg: response.envelope.message.text
+        })
+        robot.brain.set 'karmaLog', karmaLog
+        robot.brain.save()
+        response.send "#{getCleanName(targetUser.name)} ahora tiene #{targetUser.karma} puntos de karma."
+    .catch (err) ->
+      console.log(err)
 
   userForToken = (token, response) ->
     return usersForToken(token)
@@ -214,4 +221,3 @@ module.exports = (robot) ->
           karma: 0
         robot.brain.save()
       localUsers[user1.id]
-

--- a/test/karma.test.coffee
+++ b/test/karma.test.coffee
@@ -1,0 +1,207 @@
+Helper = require("hubot-test-helper")
+expect = require("chai").expect
+http = require("http")
+
+helper = new Helper("../scripts/karma.coffee")
+
+describe "karma", ->
+  beforeEach ->
+    @room = helper.createRoom()
+    @room.robot.adapter.client =
+      rtm:
+        dataStore:
+          getChannelGroupOrDMById: (room) ->
+            is_channel: true
+      web:
+        users:
+          list: () ->
+            return new Promise (resolve) ->
+              resolve members: [
+                {name: "jorgeepunan"}
+                {name: "leonardo"}
+                {name: "leon"}
+                {name: "cata"}
+              ]
+    @room.robot.brain.userForId "jorgeepunan",
+      name: "jorgeepunan"
+      id: 1
+    @room.robot.brain.userForId "leonardo",
+      name: "leonardo"
+      id: 2
+    @room.robot.brain.userForId "leon",
+      name: "leon"
+      id: 3
+    @room.robot.brain.userForId "cata",
+      name: "cata"
+      id: 4
+      karma: -99
+    @room.robot.brain.karmaLimits =
+      user:
+        3: new Date()
+    @room.robot.brain.data._private["karmaLog"] = [
+      {name: "jorgeepunan", karma: "-1", targetName: "cata", date: "2016-07-29T15:01:30.633Z", msg: "cata--"}
+    ]
+
+  afterEach ->
+    @room.destroy()
+
+  context "Karma unico", ->
+    beforeEach (done) ->
+      @room.user.say("user", "jorgee-- asdf")
+      setTimeout(done, 500)
+
+    it "Debe aplicar a un usuario", ->
+      expect(@room.messages).to.eql([
+        ["user", "jorgee-- asdf"]
+        ["hubot", "j.orgeepunan ahora tiene -1 puntos de karma."]
+      ])
+
+  context "Karma multiple", ->
+    beforeEach (done) ->
+      @room.user.say("user", "jorgee-- leonard++")
+      setTimeout(done, 500)
+
+    it "Debe aplicar a ambos usuarios", ->
+      expect(@room.messages).to.eql([
+        ["user", "jorgee-- leonard++"]
+        ["hubot", "j.orgeepunan ahora tiene -1 puntos de karma."]
+        ["hubot", "l.eonardo ahora tiene 1 puntos de karma."]
+      ])
+
+  context "Karma sin usuario", ->
+    beforeEach (done) ->
+      @room.user.say("user", "d++")
+      setTimeout(done, 500)
+
+    it "No Debe aplicar karma", ->
+      expect(@room.messages).to.eql([
+        ["user", "d++"]
+        ["hubot", "Chaucha, no encuentro al usuario 'd'."]
+      ])
+
+  context "Karma con conflicto de nombres", ->
+    beforeEach (done) ->
+      @room.user.say("user", "leo++")
+      setTimeout(done, 500)
+
+    it "No Debe aplicar karma", ->
+      expect(@room.messages).to.eql([
+        ["user", "leo++"]
+        ["hubot", "Se más específico, Hay 2 personas que se parecen a: l.eonardo, l.eon."]
+      ])
+
+  context "Karma a si mismo", ->
+    beforeEach (done) ->
+      @room.user.say("leonardo", "leonardo++")
+      setTimeout(done, 500)
+
+    it "No Debe aplicar karma", ->
+      expect(@room.messages).to.eql([
+        ["leonardo", "leonardo++"]
+        ["hubot", "Oe no po, el karma es pa otros no pa ti!"]
+      ])
+
+  context "Karma excesivo", ->
+    beforeEach (done) ->
+      @room.user.say("user", "leon++")
+      setTimeout(done, 500)
+
+    it "No Debe aplicar karma", ->
+      expect(@room.messages[0]).to.eql(["user", "leon++"])
+      expect(@room.messages[1][1]).to.match(/\¡No abuses\! Intenta en \d+ minutos/)
+
+  context "Karma todos", ->
+    beforeEach (done) ->
+      @room.user.say("user", "karma todos")
+      setTimeout(done, 500)
+
+    it "Debe mostrar url", ->
+      expect(@room.messages).to.eql([
+        ["user", "karma todos"]
+        ["hubot", "Karma de todos: http://hubot.herokuapp.com/hubot/karma/todos"]
+      ])
+
+  context "Karma de un usuario", ->
+    beforeEach (done) ->
+      @room.user.say("user", "karma leonardo")
+      setTimeout(done, 500)
+
+    it "Debe mostrar puntaje y url", ->
+      expect(@room.messages).to.eql([
+        ["user", "karma leonardo"]
+        ["hubot", "l.eonardo tiene 0 puntos de karma. Más detalles en: http://hubot.herokuapp.com/hubot/karma/log/leonardo"]
+      ])
+
+  context "Karma reset invalido", ->
+    beforeEach (done) ->
+      @room.user.say("user", "karma reset leonardo")
+      setTimeout(done, 500)
+
+    it "No debe resetar", ->
+      expect(@room.messages).to.eql([
+        ["user", "karma reset leonardo"]
+        ["hubot", "Tienes que ser :hector: para realizar esta función"]
+      ])
+
+  context "Karma reset a usuario", ->
+    beforeEach (done) ->
+      @room.user.say("hector", "karma reset leonardo")
+      setTimeout(done, 500)
+
+    it "No debe resetar", ->
+      expect(@room.messages).to.eql([
+        ["hector", "karma reset leonardo"]
+        ["hubot", "l.eonardo ha quedado libre de toda bendición o pecado."]
+      ])
+
+  context "Karma reset a todos", ->
+    beforeEach (done) ->
+      @room.user.say("hector", "karma reset todos")
+      setTimeout(done, 500)
+
+    it "No debe resetar", ->
+      expect(@room.messages).to.eql([
+        ["hector", "karma reset todos"]
+        ["hubot", "Todo el mundo ha quedado libre de toda bendición o pecado."]
+      ])
+
+  context "GET /hubot/karma/todos", ->
+    beforeEach (done) ->
+      http.get "http://localhost:8080/hubot/karma/todos", (@response) => done()
+      .on 'error', done
+
+    it "Responde con status 200", ->
+      @response.on "data", (chunk) ->
+        expect(chunk.toString()).to.eql("Karma de todos:\n <ul> <li>-99 <strong>cata</strong></li> </ul>")
+      expect(@response.statusCode).to.eql 200
+
+  context "Karma multiple mismo usuario", ->
+    beforeEach (done) ->
+      @room.user.say("user", "jorgee-- jorgee-- jorgee--")
+      setTimeout(done, 500)
+
+    it "Debe aplicar un solo karma", ->
+      expect(@room.messages[0]).to.eql(["user", "jorgee-- jorgee-- jorgee--"])
+      expect(@room.messages[1][1]).to.eql("j.orgeepunan ahora tiene -1 puntos de karma.")
+      expect(@room.messages[2][1]).to.match(/\¡No abuses\! Intenta en \d+ minutos/)
+      expect(@room.messages[3][1]).to.match(/\¡No abuses\! Intenta en \d+ minutos/)
+
+  context "GET /hubot/karma/log", ->
+    beforeEach (done) ->
+      http.get "http://localhost:8080/hubot/karma/log", (@response) => done()
+      .on 'error', done
+
+    it "Responde con status 200", ->
+      @response.on "data", (chunk) ->
+        expect(chunk.toString()).to.eql("Karmalog:\n <ul> <li>jorgeepunan le ha dado -1 karma a cata - 2016-07-29T15:01:30.633Z</li> </ul>")
+      expect(@response.statusCode).to.eql 200
+
+  context "GET /hubot/karma/log/:user", ->
+    beforeEach (done) ->
+      http.get "http://localhost:8080/hubot/karma/log/cata", (@response) => done()
+      .on 'error', done
+
+    it "Responde con status 200", ->
+      @response.on "data", (chunk) ->
+        expect(chunk.toString()).to.eql("Karmalog: <ul> <li>2016-07-29T15:01:30.633Z - jorgeepunan: cata--</li> </ul>")
+      expect(@response.statusCode).to.eql 200


### PR DESCRIPTION
Uso anteriormente:

```
<= usuario1++ usuario2++
=> solo usuario 1 recibe karma
```

Uso con este cambio:

```
<= usuario1++ usuario2++ usuario3-- blabla usuario4++
=> usuario1, usuario2, usuario4, reciben karma
=> usuario3 pierde karma
```
