### PR TITLE
Se agrego webhook para recibir notificaciones de travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "7"
 notifications:
   email: false
+  webhooks: http://huemul.herokuapp.com/travis-ci/huemul-devs
 env:
   - CXX=g++-4.8
 addons:

--- a/external-scripts.json
+++ b/external-scripts.json
@@ -32,6 +32,7 @@
   "hubot-rules",
   "hubot-shipit",
   "hubot-soon",
+  "hubot-travis-ci-hook",
   "hubot-tweets",
   "hubot-wikipedia-lang",
   "hubot-youtube",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "hubot-shipit": "^0.2.0",
     "hubot-slack": "^4.3.1",
     "hubot-soon": "^1.0.0",
+    "hubot-travis-ci-hook": "0.0.1",
     "hubot-tweets": "devschile/hubot-tweets",
     "hubot-wikipedia-lang": "^1.0.1",
     "hubot-youtube": "^1.0.2",


### PR DESCRIPTION
Hay dos diseños:
Full
![full](https://camo.githubusercontent.com/7a7cf17bbd338d92de58ef44e663451214870d54/687474703a2f2f7069782e746f696c652d6c696272652e6f72672f75706c6f61642f6f726967696e616c2f313438383234363632312e706e67)
Short
![short](https://camo.githubusercontent.com/8cd468f74e35e7f504dfd5040ddecb5a547ae68d/687474703a2f2f7069782e746f696c652d6c696272652e6f72672f75706c6f61642f6f726967696e616c2f313438383234363636352e706e67)
Por defecto es el diseño full, pero se puede cambiar estableciendo la variable de entorno TRAVIS_SHORT=true
El icono de travis es random entre 15 diseños oficiales distintos