### PR TITLE
fix(env): Se quito lectura de .env

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -3,9 +3,5 @@
 set -e
 
 export PATH="node_modules/.bin:node_modules/hubot/node_modules/.bin:$PATH"
-if [ -f "${PWD}/.env" ]
-then
-  export $(cat ${PWD}/.env | xargs)
-fi
 
 exec node_modules/.bin/hubot --name "huemul" "$@"


### PR DESCRIPTION
Creo que esto corrige a :huemul:, leyendo un .env dentro del contenedor docker de dokku, en otro formato del esperado