### PR TITLE
Agregamos las publicaciones de Medios Regionales

### DIFF
--- a/scripts/portadas.coffee
+++ b/scripts/portadas.coffee
@@ -22,13 +22,14 @@ lista_portadas = (msg) ->
     (la)? cuarta
     ((las)? ultimas noticias)|lun
     (el)? mercurio$
-    (el)? mercurio ((de)? calama|antofagasta|valparaiso)?
-    (la)? estrella ((del?)? arica|iquique|loa|antofagasta|tocopilla|valparaiso|quillota|concepcion|chiloe)
+    (el)? mercurio ((de)? calama|antofagasta|valparaíso)?
+    (la)? estrella ((del?)? arica|iquique|loa|antofagasta|tocopilla|valparaíso|quillota|concepción|chiloé)
     (el)? sur
     (el)? austral ((de)? temuco|valdivia|osorno)
     (el)? llanquihue
-    (el)? lider (de san antonio)?
+    (el)? líder (de san antonio)?
     (el)? diario (de)? atacama
+    crónica chillán
     hoyxhoy
     publimetro
   *Uruguay:*

--- a/scripts/portadas.coffee
+++ b/scripts/portadas.coffee
@@ -20,8 +20,16 @@ lista_portadas = (msg) ->
     (la)? segunda
     (la)? tercera
     (la)? cuarta
-    (el)? mercurio
     ((las)? ultimas noticias)|lun
+    (el)? mercurio$
+    (el)? mercurio ((de)? calama|antofagasta|valparaiso)?
+    (la)? estrella ((del?)? arica|iquique|loa|antofagasta|tocopilla|valparaiso|quillota|concepcion|chiloe)
+    (el)? sur
+    (el)? austral ((de)? temuco|valdivia|osorno)
+    (el)? llanquihue
+    (el)? lider (de san antonio)?
+    (el)? diario (de)? atacama
+    hoyxhoy
     publimetro
   *Uruguay:*
     (el)? pais (uruguay|uru|uy)
@@ -65,8 +73,8 @@ get_portada = (msg, diario, days_past = 0) ->
 
 module.exports = (robot) ->
   robot.respond /portada (.*)/i, (msg) ->
-    nombre = msg.match[1].replace(/^(las |la |el |le |the |o |il )/, "").replace(/( )/g, "")
-
+    nombre = msg.match[1].replace(/^(las |la |el |le |the |o |il )/, "").replace(/( de | del | de la )/, "").replace(/( )/g, "")
+    
     diario = switch(nombre)
       # Chile
       when "segunda" then { url: "http://www.portadaschilenas.com/#DATE#/Lasegunda_grande.jpg", no_slashes: false }
@@ -76,6 +84,47 @@ module.exports = (robot) ->
       when "mercurio" then { url: "http://www.portadaschilenas.com/#DATE#/Emol_grande.jpg", no_slashes: false }
       when "ultimasnoticias" then { url: "http://www.portadaschilenas.com/#DATE#/Lun_grande.jpg", no_slashes: false }
       when "lun" then { url: "http://www.portadaschilenas.com/#DATE#/Lun_grande.jpg", no_slashes: false }
+        
+      # Chile, Medios Regionales (por orden geográfico)
+      when "estrellaarica" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaArica/01-1440.jpg", no_slashes: false}
+      when "estrellaiquique" then { url: "http://edicionimpresa.soychile.cl/portadas/EstellaIquique/01-1440.jpg", no_slashes: false}
+      when "mercuriocalama" then { url: "http://edicionimpresa.soychile.cl/portadas/MercurioCalama/01-1440.jpg", no_slashes: false}
+      when "estrellaloa" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaLoa/01-1440.jpg", no_slashes: false}
+      when "estrellatocopilla" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaTocopilla/01-1440.jpg", no_slashes: false}
+      when "mercurioantofagasta" then { url: "http://edicionimpresa.soychile.cl/portadas/ElMercuriodeAntofagasta/01-1440.jpg", no_slashes: false}
+      when "mercurioantofa" then { url: "http://edicionimpresa.soychile.cl/portadas/ElMercuriodeAntofagasta/01-1440.jpg", no_slashes: false}
+      when "estrellaantofagasta" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaAntofagasta/01-1440.jpg", no_slashes: false}
+      when "estrellaantofa" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaAntofagasta/01-1440.jpg", no_slashes: false}
+      when "diarioatacama" then { url: "http://edicionimpresa.soychile.cl/portadas/DiarioAtacama/01-1440.jpg", no_slashes: false}
+      when "mercuriovalparaiso" then { url: "http://edicionimpresa.soychile.cl/portadas/MercurioValparaiso/01-1440.jpg", no_slashes: false}
+      when "mercuriovalparaíso" then { url: "http://edicionimpresa.soychile.cl/portadas/MercurioValparaiso/01-1440.jpg", no_slashes: false}
+      when "mercuriovalpo" then { url: "http://edicionimpresa.soychile.cl/portadas/MercurioValparaiso/01-1440.jpg", no_slashes: false}
+      when "estrellavalparaiso" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaValparaiso/01-1440.jpg", no_slashes: false}
+      when "estrellavalparaíso" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaValparaiso/01-1440.jpg", no_slashes: false}
+      when "estrellavalpo" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaValparaiso/01-1440.jpg", no_slashes: false}
+      when "estrellaquillota" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaQuillota/01-1440.jpg", no_slashes: false}
+      when "lider" then { url: "http://edicionimpresa.soychile.cl/portadas/LiderSanAntonio/01-1440.jpg", no_slashes: false}
+      when "líder" then { url: "http://edicionimpresa.soychile.cl/portadas/LiderSanAntonio/01-1440.jpg", no_slashes: false}
+      when "lidersanantonio" then { url: "http://edicionimpresa.soychile.cl/portadas/LiderSanAntonio/01-1440.jpg", no_slashes: false}
+      when "lídersanantonio" then { url: "http://edicionimpresa.soychile.cl/portadas/LiderSanAntonio/01-1440.jpg", no_slashes: false}
+      when "sur" then { url: "http://edicionimpresa.soychile.cl/portadas/ElSur/01-1440.jpg", no_slashes: false}
+      when "estrellaconcepcion" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaConcepcion/01-1440.jpg", no_slashes: false}
+      when "estrellaconcepción" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaConcepcion/01-1440.jpg", no_slashes: false}
+      when "estrellaconce" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaConcepcion/01-1440.jpg", no_slashes: false}
+      when "cronicachillan" then { url: "http://edicionimpresa.soychile.cl/portadas/CronicaChillan/01-1440.jpg", no_slashes: false}
+      when "crónicachillan" then { url: "http://edicionimpresa.soychile.cl/portadas/CronicaChillan/01-1440.jpg", no_slashes: false}
+      when "cronicachillán" then { url: "http://edicionimpresa.soychile.cl/portadas/CronicaChillan/01-1440.jpg", no_slashes: false}
+      when "crónicachillán" then { url: "http://edicionimpresa.soychile.cl/portadas/CronicaChillan/01-1440.jpg", no_slashes: false}
+      when "australtemuco" then { url: "http://edicionimpresa.soychile.cl/portadas/AustralTemuco/01-1440.jpg", no_slashes: false}
+      when "australlosrios" then { url: "http://edicionimpresa.soychile.cl/portadas/AustralValdivia/01-1440.jpg", no_slashes: false}
+      when "australlosríos" then { url: "http://edicionimpresa.soychile.cl/portadas/AustralValdivia/01-1440.jpg", no_slashes: false}
+      when "australvaldivia" then { url: "http://edicionimpresa.soychile.cl/portadas/AustralValdivia/01-1440.jpg", no_slashes: false}
+      when "australosorno" then { url: "http://edicionimpresa.soychile.cl/portadas/AustralOsorno/01-1440.jpg", no_slashes: false}
+      when "llanquihue" then { url: "http://edicionimpresa.soychile.cl/portadas/Llanquihue/01-1440.jpg", no_slashes: false}
+      when "estrellachiloe" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaChiloe/01-1440.jpg", no_slashes: false}
+      when "estrellachiloé" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaChiloe/01-1440.jpg", no_slashes: false}
+      when "hoyxhoy" then { url: "http://edicionimpresa.soychile.cl/portadas/HoyxHoy/01-1440.jpg", no_slashes: false}
+      when "hxh" then { url: "http://edicionimpresa.soychile.cl/portadas/HoyxHoy/01-1440.jpg", no_slashes: false}
 
       # Brasil
       when "globo" then { url: "http://img.kiosko.net/#DATE#/br/br_oglobo.750.jpg", no_slashes: false}

--- a/scripts/portadas.coffee
+++ b/scripts/portadas.coffee
@@ -74,8 +74,8 @@ get_portada = (msg, diario, days_past = 0) ->
 
 module.exports = (robot) ->
   robot.respond /portada (.*)/i, (msg) ->
-    nombre = msg.match[1].replace(/^(las |la |el |le |the |o |il )/, "").replace(/( de | del | de la )/, "").replace(/( )/g, "");
-    nombre = nombre.replace("antofagasta", "antofa").replace(/valpara(?:í|i)so$/, "valpo").replace("líder", "lider").replace(/concepci(?:ó|o)n$/, "conce").replace("crónica", "cronica").replace("chillán","chillan").replace("losríos", "losrios").replace("chiloé", "chiloe");
+    nombre = msg.match[1].replace(/^(las |la |el |le |the |o |il )/, "").replace(/( de | del | de la )/, "").replace(/( )/g, "")
+    nombre = nombre.replace("antofagasta", "antofa").replace(/valpara(?:í|i)so$/, "valpo").replace("líder", "lider").replace(/concepci(?:ó|o)n$/, "conce").replace("crónica", "cronica").replace("chillán","chillan").replace("losríos", "losrios").replace("chiloé", "chiloe")
     
     diario = switch(nombre)
       # Chile

--- a/scripts/portadas.coffee
+++ b/scripts/portadas.coffee
@@ -75,7 +75,7 @@ get_portada = (msg, diario, days_past = 0) ->
 module.exports = (robot) ->
   robot.respond /portada (.*)/i, (msg) ->
     nombre = msg.match[1].replace(/^(las |la |el |le |the |o |il )/, "").replace(/( de | del | de la )/, "").replace(/( )/g, "")
-    nombre = nombre.replace("antofagasta", "antofa").replace(/valpara(?:í|i)so$/, "valpo").replace("líder", "lider").replace(/concepci(?:ó|o)n$/, "conce").replace("crónica", "cronica").replace("chillán","chillan").replace("losríos", "losrios").replace("chiloé", "chiloe")
+    nombre = nombre.replace(/antofagasta$/, "antofa").replace(/valpara(?:í|i)so$/, "valpo").replace(/líder/, "lider").replace(/concepci(?:ó|o)n$/, "conce").replace(/crónica/, "cronica").replace(/chillán$/,"chillan").replace(/losríos$/, "losrios").replace(/chiloé$/, "chiloe")
     
     diario = switch(nombre)
       # Chile

--- a/scripts/portadas.coffee
+++ b/scripts/portadas.coffee
@@ -27,7 +27,7 @@ lista_portadas = (msg) ->
     (el)? sur
     (el)? austral ((de)? temuco|valdivia|osorno)
     (el)? llanquihue
-    (el)? líder (de san antonio)?
+    (el)? l(í|i)der (de san antonio)?
     (el)? diario (de)? atacama
     cr(ó|o)nica chill(á|a)n
     hoyxhoy

--- a/scripts/portadas.coffee
+++ b/scripts/portadas.coffee
@@ -74,7 +74,8 @@ get_portada = (msg, diario, days_past = 0) ->
 
 module.exports = (robot) ->
   robot.respond /portada (.*)/i, (msg) ->
-    nombre = msg.match[1].replace(/^(las |la |el |le |the |o |il )/, "").replace(/( de | del | de la )/, "").replace(/( )/g, "")
+    nombre = msg.match[1].replace(/^(las |la |el |le |the |o |il )/, "").replace(/( de | del | de la )/, "").replace(/( )/g, "");
+    nombre = nombre.replace("antofagasta", "antofa").replace(/valpara(?:í|i)so$/, "valpo").replace("líder", "lider").replace(/concepci(?:ó|o)n$/, "conce").replace("crónica", "cronica").replace("chillán","chillan").replace("losríos", "losrios").replace("chiloé", "chiloe");
     
     diario = switch(nombre)
       # Chile
@@ -92,38 +93,23 @@ module.exports = (robot) ->
       when "mercuriocalama" then { url: "http://edicionimpresa.soychile.cl/portadas/MercurioCalama/01-1440.jpg", no_slashes: false}
       when "estrellaloa" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaLoa/01-1440.jpg", no_slashes: false}
       when "estrellatocopilla" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaTocopilla/01-1440.jpg", no_slashes: false}
-      when "mercurioantofagasta" then { url: "http://edicionimpresa.soychile.cl/portadas/ElMercuriodeAntofagasta/01-1440.jpg", no_slashes: false}
       when "mercurioantofa" then { url: "http://edicionimpresa.soychile.cl/portadas/ElMercuriodeAntofagasta/01-1440.jpg", no_slashes: false}
-      when "estrellaantofagasta" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaAntofagasta/01-1440.jpg", no_slashes: false}
       when "estrellaantofa" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaAntofagasta/01-1440.jpg", no_slashes: false}
       when "diarioatacama" then { url: "http://edicionimpresa.soychile.cl/portadas/DiarioAtacama/01-1440.jpg", no_slashes: false}
-      when "mercuriovalparaiso" then { url: "http://edicionimpresa.soychile.cl/portadas/MercurioValparaiso/01-1440.jpg", no_slashes: false}
-      when "mercuriovalparaíso" then { url: "http://edicionimpresa.soychile.cl/portadas/MercurioValparaiso/01-1440.jpg", no_slashes: false}
       when "mercuriovalpo" then { url: "http://edicionimpresa.soychile.cl/portadas/MercurioValparaiso/01-1440.jpg", no_slashes: false}
-      when "estrellavalparaiso" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaValparaiso/01-1440.jpg", no_slashes: false}
-      when "estrellavalparaíso" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaValparaiso/01-1440.jpg", no_slashes: false}
       when "estrellavalpo" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaValparaiso/01-1440.jpg", no_slashes: false}
       when "estrellaquillota" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaQuillota/01-1440.jpg", no_slashes: false}
       when "lider" then { url: "http://edicionimpresa.soychile.cl/portadas/LiderSanAntonio/01-1440.jpg", no_slashes: false}
-      when "líder" then { url: "http://edicionimpresa.soychile.cl/portadas/LiderSanAntonio/01-1440.jpg", no_slashes: false}
       when "lidersanantonio" then { url: "http://edicionimpresa.soychile.cl/portadas/LiderSanAntonio/01-1440.jpg", no_slashes: false}
-      when "lídersanantonio" then { url: "http://edicionimpresa.soychile.cl/portadas/LiderSanAntonio/01-1440.jpg", no_slashes: false}
       when "sur" then { url: "http://edicionimpresa.soychile.cl/portadas/ElSur/01-1440.jpg", no_slashes: false}
-      when "estrellaconcepcion" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaConcepcion/01-1440.jpg", no_slashes: false}
-      when "estrellaconcepción" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaConcepcion/01-1440.jpg", no_slashes: false}
       when "estrellaconce" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaConcepcion/01-1440.jpg", no_slashes: false}
       when "cronicachillan" then { url: "http://edicionimpresa.soychile.cl/portadas/CronicaChillan/01-1440.jpg", no_slashes: false}
-      when "crónicachillan" then { url: "http://edicionimpresa.soychile.cl/portadas/CronicaChillan/01-1440.jpg", no_slashes: false}
-      when "cronicachillán" then { url: "http://edicionimpresa.soychile.cl/portadas/CronicaChillan/01-1440.jpg", no_slashes: false}
-      when "crónicachillán" then { url: "http://edicionimpresa.soychile.cl/portadas/CronicaChillan/01-1440.jpg", no_slashes: false}
       when "australtemuco" then { url: "http://edicionimpresa.soychile.cl/portadas/AustralTemuco/01-1440.jpg", no_slashes: false}
       when "australlosrios" then { url: "http://edicionimpresa.soychile.cl/portadas/AustralValdivia/01-1440.jpg", no_slashes: false}
-      when "australlosríos" then { url: "http://edicionimpresa.soychile.cl/portadas/AustralValdivia/01-1440.jpg", no_slashes: false}
       when "australvaldivia" then { url: "http://edicionimpresa.soychile.cl/portadas/AustralValdivia/01-1440.jpg", no_slashes: false}
       when "australosorno" then { url: "http://edicionimpresa.soychile.cl/portadas/AustralOsorno/01-1440.jpg", no_slashes: false}
       when "llanquihue" then { url: "http://edicionimpresa.soychile.cl/portadas/Llanquihue/01-1440.jpg", no_slashes: false}
       when "estrellachiloe" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaChiloe/01-1440.jpg", no_slashes: false}
-      when "estrellachiloé" then { url: "http://edicionimpresa.soychile.cl/portadas/EstrellaChiloe/01-1440.jpg", no_slashes: false}
       when "hoyxhoy" then { url: "http://edicionimpresa.soychile.cl/portadas/HoyxHoy/01-1440.jpg", no_slashes: false}
       when "hxh" then { url: "http://edicionimpresa.soychile.cl/portadas/HoyxHoy/01-1440.jpg", no_slashes: false}
 

--- a/scripts/portadas.coffee
+++ b/scripts/portadas.coffee
@@ -22,14 +22,14 @@ lista_portadas = (msg) ->
     (la)? cuarta
     ((las)? ultimas noticias)|lun
     (el)? mercurio$
-    (el)? mercurio ((de)? calama|antofagasta|valparaíso)?
-    (la)? estrella ((del?)? arica|iquique|loa|antofagasta|tocopilla|valparaíso|quillota|concepción|chiloé)
+    (el)? mercurio ((de)? calama|antofa(gasta)?|valpara(í|i)so|valpo)?
+    (la)? estrella ((del?)? arica|iquique|loa|antofa(gasta)?|tocopilla|valpara(í|i)so|valpo|quillota|concepci(ó|o)n|chilo(é|e))
     (el)? sur
     (el)? austral ((de)? temuco|valdivia|osorno)
     (el)? llanquihue
     (el)? líder (de san antonio)?
     (el)? diario (de)? atacama
-    crónica chillán
+    cr(ó|o)nica chill(á|a)n
     hoyxhoy
     publimetro
   *Uruguay:*


### PR DESCRIPTION
El departamento de "_ta madre, se pone a codear en Montevideo_" les presenta la adenda para los diarios dentro del paraguas de Medios Regionales

Incluye desambiguación en el listado (por la coincidencia de El Mercurio con los 3 diarios que comparten ese nombre) y diversos casos de acentuación ("Crónica Chillán", por ejemplo)

## Ejemplos

`huemul portada la estrella de arica`
`huemul portada mercuriovalpo`
`huemul portada hxh`

/cc @lgaticaq @juanbrujo 