### PR TITLE
Se agrego enviar errores a Sentry

### DIFF
--- a/scripts/error-handler.js
+++ b/scripts/error-handler.js
@@ -1,0 +1,41 @@
+// Description:
+//   Send errors to sentry.io
+//
+// Dependencies:
+//   raven
+//
+// Configuration:
+//   SENTRY_DSN, SENTRY_ENVIRONMENT, SENTRY_NAME
+//
+// Commands:
+//   None
+
+const Raven = require('raven')
+
+module.exports = robot => {
+  if (!process.env.SENTRY_DSN) {
+    robot.logger.warning(
+      'The SENTRY_DSN environment variable not set. Sentry not configured.')
+  }
+
+  Raven.config().install()
+
+  robot.error((err, res) => {
+    robot.logger.error(err)
+    if (typeof res !== 'undefined' && res !== null) {
+      if (['SlackBot', 'Room'].includes(robot.adapter.constructor.name) && res.message) {
+        Raven.setContext({
+          user: {
+            id: res.message.user.id,
+            username: res.message.user.name,
+            email: res.message.user.email
+          }
+        })
+      }
+      if (typeof res.reply === 'function') {
+        res.reply(`an error has occurred: \`${err.message}\``)
+      }
+    }
+    Raven.captureException(err)
+  })
+}


### PR DESCRIPTION
Es necesario configurar la variable de entorno `SENTRY_DSN`