### PR TITLE
Feature/add prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "semi": false
+  "semi": false,
+  "printWidth": 120
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": false,
+  "noSemi": true
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,4 @@
 {
-  "singleQuote": false,
-  "noSemi": true
+  "singleQuote": true,
+  "semi": false
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,11 @@
   "scripts": {
     "start": "bin/hubot -a slack",
     "dev": "bin/hubot",
-    "test": "ava test"
+    "test": "ava test",
+    "precommit": "lint-staged"
+  },
+  "lint-staged": {
+    "*.{js,json,css,md}": ["prettier --write", "git add"]
   },
   "engines": {
     "node": "6.9.x"
@@ -15,9 +19,7 @@
     "type": "git",
     "url": "git://github.com/devschile/huemul.git"
   },
-  "keywords": [
-    "hubot"
-  ],
+  "keywords": ["hubot"],
   "author": "Huemul",
   "private": true,
   "bugs": {
@@ -99,6 +101,9 @@
     "ava": "^0.21.0",
     "coffee-script": "^1.12.7",
     "hubot-test-helper": "1.5.1",
-    "nock": "^9.0.14"
+    "husky": "^0.14.3",
+    "lint-staged": "^6.0.0",
+    "nock": "^9.0.14",
+    "prettier": "1.9.2"
   }
 }


### PR DESCRIPTION
Soluciona parte del #220 

El PR agrega prettier al huemul. Cuando se va a hacer commit luego de pasar los cambios a staging se ejecuta un precommit que formatea el código en base a ciertas reglas por defecto, entre ellas esta usar comillas sencillas, remover los `;` y poner un maximo de 100 caracteres por linea.

https://media.giphy.com/media/xUOxeQj1PBDwG8JuSs/giphy.gif

Se puede correr prettier sobre el todo el proyecto para normalizar el formato pero creo que es mejor hacerlo en otro PR para no tener tantos archivos modificados.