### PR TITLE
Pequeña optimizacion para obtener el precio en orionx

### DIFF
--- a/scripts/orionx.js
+++ b/scripts/orionx.js
@@ -56,7 +56,7 @@ module.exports = robot => {
     const url = 'http://api.orionx.io/graphql'
     const query = `{
       marketTradeHistory(marketCode: "${coinId}") {
-        prices
+        price
       }
     }`
 

--- a/scripts/orionx.js
+++ b/scripts/orionx.js
@@ -56,11 +56,7 @@ module.exports = robot => {
     const url = 'http://api.orionx.io/graphql'
     const query = `{
       marketTradeHistory(marketCode: "${coinId}") {
-        _id
-        amount
-        price
-        totalCost
-        date
+        prices
       }
     }`
 


### PR DESCRIPTION
Habian campos que no se usaban en la consulta, asi que solo deje `price` de esta forma se ahorran un par de _ms_