### PR TITLE
Se agrego docker-compose.yml para levantar mongo en dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,56 +2,57 @@
 
 El repositorio de Huemul queda abierto para todos los miembros de [devsChile en GitHub](https://github.com/devschile).
 
-En la medida que sea posible todo script *complejo* que se quiera agregar debería ser su propio paquete de npm, ya sea el original o un fork con los cambios en esta organización u otra parte. **Una buena regla es que si tu script tiene dependencias debería ser su propio paquete, sino puede ir en la carpeta de scripts.**
+En la medida que sea posible todo script _complejo_ que se quiera agregar debería ser su propio paquete de npm, ya sea el original o un fork con los cambios en esta organización u otra parte. **Una buena regla es que si tu script tiene dependencias debería ser su propio paquete, sino puede ir en la carpeta de scripts.**
 
 ## Pasos:
 
-- Fork a tu cuenta de GitHub y clone este repo en tu local.
-- `$ cd ruta/a/huemul`
-- `$ npm install` (probablemente sea mejor usar `sudo` a menos que uses nodenv o nvm).
-- Si estás usando la carpeta de scripts deja tu código en `huemul/scripts`, sino:
+* Fork a tu cuenta de GitHub y clone este repo en tu local.
+* `$ cd ruta/a/huemul`
+* `$ npm install` o `$ yarn` (probablemente sea mejor usar `sudo` a menos que uses nodenv o nvm).
+* Si estás usando la carpeta de scripts deja tu código en `huemul/scripts`, sino:
 
 --
 
-- `npm install -g yo generator-hubot` para instalar el generador de hubot.
-- `yo hubot:script` en la carpeta correspondiente para crear el template para un script.
-- Una vez [publicado el paquete en npm](https://gist.github.com/coolaj86/1318304) agrégalo a `external-scripts.json` y `package.json`.
+* `npm install -g yo generator-hubot` para instalar el generador de hubot.
+* `yo hubot:script` en la carpeta correspondiente para crear el template para un script.
+* Una vez [publicado el paquete en npm](https://gist.github.com/coolaj86/1318304) agrégalo a `external-scripts.json` y `package.json`.
 
 --
 
-- Para probar tus cambios localmente: `$ bin/hubot` y activarás a Huemul. Ahora ya podrás invocarlo junto con sus comandos y los que hayas escrito.
-- Para enviar tus cambios a Huemul, los pasos son:
-  - Haz un [_pull request_](https://github.com/devschile/huemul/pulls) y explica lo que hiciste. Agrega el comando para probarlo en el comentario.
-  - Agrega como reviewers a [@leonardo](https://devschile.slack.com/messages/huemul-devs/team/leonardo/), [@hector](https://devschile.slack.com/messages/huemul-devs/team/hector/), [@gmq](https://devschile.slack.com/messages/huemul-devs/team/gmq/) y/o [@jorgeepunan](https://devschile.slack.com/messages/huemul-devs/team/jorgeepunan/).
-  - Coméntalo en [Slack devsChile](http://www.devschile.cl) canal [*#huemul-devs*](http://devschile.slack.com/messages/huemul-devs) y será revisado, testeado, linteado y, si pasa los rigurosos análisis, será agregado.
--  Para más información sobre *Hubot* consulta [Hubot Documentation > Scripting](https://hubot.github.com/docs/scripting/).
--  **No olvides documentar tu código**.
+* Es necesario tener MongoDB instalado o bien usar `$ docker-compose up -d` para iniciar un contenedor con MongoDB expuesto al puerto 27017 en tu localhost. Para detener el servicio de MongoDB debes ejecutar `$ docker-compose stop`.
+* Para probar tus cambios localmente: `$ npm run dev` y activarás a Huemul. Ahora ya podrás invocarlo junto con sus comandos y los que hayas escrito.
+* Para enviar tus cambios a Huemul, los pasos son:
+  * Haz un [_pull request_](https://github.com/devschile/huemul/pulls) y explica lo que hiciste. Agrega el comando para probarlo en el comentario.
+  * Agrega como reviewers a [@leonardo](https://devschile.slack.com/messages/huemul-devs/team/leonardo/), [@hector](https://devschile.slack.com/messages/huemul-devs/team/hector/), [@gmq](https://devschile.slack.com/messages/huemul-devs/team/gmq/) y/o [@jorgeepunan](https://devschile.slack.com/messages/huemul-devs/team/jorgeepunan/).
+  * Coméntalo en [Slack devsChile](http://www.devschile.cl) canal [_#huemul-devs_](http://devschile.slack.com/messages/huemul-devs) y será revisado, testeado, linteado y, si pasa los rigurosos análisis, será agregado.
+* Para más información sobre _Hubot_ consulta [Hubot Documentation > Scripting](https://hubot.github.com/docs/scripting/).
+* **No olvides documentar tu código**.
 
 ```
-                                 ;;;;;;   ;;;                  
-                                 @@@@@@   @@@                  
-                              ;;;+++@@@;;;+++;;;               
-                              @@@;;;@@@@@@;;;@@@               
-                              @@@;;;@@@@@@;;;@@@               
-                              @@@;;;;;;;;;;;;@@@               
-                                 @@@;;;@@@;;;;;;@@@            
-                                 @@@;;;@@@;;;;;;@@@            
-                                 @@@;;;;;;;;;;;;;;;@@@         
-                                 @@@;;;;;;;;;;;;;;;@@@         
-   @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@;;;;;;;;;;;;;;;@@@@@@         
-   @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@;;;;;;;;;;;;;;;@@@@@@         
-@@@......:;;;;;;;;;;;;;;;;;;;;;;;;;;;@@@@@@@@@            
-@@@......:;;;;;;;;;;;;;;;;;;;;;;;;;;;@@@@@@@@@            
-   @@@+;;;;;;;;;;;;;;;;;;;;;;;;;;;@@@                     
-   @@@+;;;;;;;;;;;;;;;;;;;;;;;;;;;@@@                     
-   @@@+;;;;;;;;;;;;;;;;;;;;;;;;@@@                        
-   @@@+;;;;;;;;;;;;;;;;;;;;;;;;@@@                        
-      ;@@+;;;;;;@@@@@@@@@;;;;;;@@@                        
-      ;@@+;;;;;;@@@@@@@@@;;;;;;@@@                        
-   @@@+;;;;;;@@@         @@@;;;@@@                        
-   @@@+;;;;;;@@@         @@@;;;@@@                        
-   @@@'..'@@@            @@@...@@@                        
-   @@@'..'@@@            @@@...@@@                        
-      ;@@;                  @@@                           
+                                 ;;;;;;   ;;;
+                                 @@@@@@   @@@
+                              ;;;+++@@@;;;+++;;;
+                              @@@;;;@@@@@@;;;@@@
+                              @@@;;;@@@@@@;;;@@@
+                              @@@;;;;;;;;;;;;@@@
+                                 @@@;;;@@@;;;;;;@@@
+                                 @@@;;;@@@;;;;;;@@@
+                                 @@@;;;;;;;;;;;;;;;@@@
+                                 @@@;;;;;;;;;;;;;;;@@@
+   @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@;;;;;;;;;;;;;;;@@@@@@
+   @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@;;;;;;;;;;;;;;;@@@@@@
+@@@......:;;;;;;;;;;;;;;;;;;;;;;;;;;;@@@@@@@@@
+@@@......:;;;;;;;;;;;;;;;;;;;;;;;;;;;@@@@@@@@@
+   @@@+;;;;;;;;;;;;;;;;;;;;;;;;;;;@@@
+   @@@+;;;;;;;;;;;;;;;;;;;;;;;;;;;@@@
+   @@@+;;;;;;;;;;;;;;;;;;;;;;;;@@@
+   @@@+;;;;;;;;;;;;;;;;;;;;;;;;@@@
+      ;@@+;;;;;;@@@@@@@@@;;;;;;@@@
+      ;@@+;;;;;;@@@@@@@@@;;;;;;@@@
+   @@@+;;;;;;@@@         @@@;;;@@@
+   @@@+;;;;;;@@@         @@@;;;@@@
+   @@@'..'@@@            @@@...@@@
+   @@@'..'@@@            @@@...@@@
+      ;@@;                  @@@
       ;@@;                  @@@
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+---
+version: '2'
+services:
+  mongo:
+    image: mvertes/alpine-mongo:3.6.3-0
+    ports:
+      - 27017:27017
+    volumes:
+      - mongo-data:/data/db
+
+volumes:
+  mongo-data:


### PR DESCRIPTION
Necesario para los huemul developers que solo usan bases de datos con docker. Ya que ahora es necesario tener mongo escuchando peticiones para levantar huemul en dev.