### PR TITLE
fix(deps): update bip to v3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/devschile/huemul#readme",
   "dependencies": {
-    "bip": "3.0.1",
+    "bip": "3.0.2",
     "cheerio": "1.0.0-rc.2",
     "correos-chile": "^1.2.4",
     "csv-streamify": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -818,9 +818,9 @@ binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
 
-bip@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/bip/-/bip-3.0.1.tgz#ad7cc0faf6a01ce14efd3ef3eafa40e120ab06aa"
+bip@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/bip/-/bip-3.0.2.tgz#e73937ed7057ca113e3490055504c2ba8d23a466"
   dependencies:
     cheerio "1.0.0-rc.2"
 


### PR DESCRIPTION
Se actualiza la lib [bip](https://github.com/lgaticaq/bip) para solucionar el error de obtener saldos negativos