### PR TITLE
fix(tableflipper) fix urls and response to display gifs

### DIFF
--- a/scripts/flipper.js
+++ b/scripts/flipper.js
@@ -15,10 +15,10 @@
 
 module.exports = function(robot) {
   robot.respond(/flip/i, function(msg) {
-    var url = 'http://tableflipper.com/json'
+    var url = 'http://www.tableflipper.com/json'
     robot.http(url).get()(function(err, res, body) {
       var data = JSON.parse(body)
-      msg.send(data.gif)
+      msg.send(data.gif.replace('http://', 'http://www.'))
     })
   })
 }


### PR DESCRIPTION
El kl le puso `www` y la respuesta viene sin `www` así que tampoco iba a funcionar solo cambiando la URL:
* http://www.tableflipper.com/json