### PR TITLE
Karma final final

### DIFF
--- a/scripts/karma.js
+++ b/scripts/karma.js
@@ -24,7 +24,7 @@ module.exports = robot => {
   const hubotHost = process.env.HEROKU_URL || process.env.HUBOT_URL || 'http://localhost:8080'
   const hubotWebSite = `${hubotHost}/${robot.name}`
 
-  const getCleanName = user => user.profile.display_name_normalized || user.real_name
+  const getCleanName = user => user.profile.display_name_normalized || user.real_name || 'Usuario desconocido'
 
   const usersForToken = token => {
     return getUsers().then(userList => userFromList(userList, token))

--- a/scripts/karma.js
+++ b/scripts/karma.js
@@ -82,6 +82,7 @@ module.exports = robot => {
 
     return userList.filter(
       user =>
+        !user.deleted &&
         getCleanName(user)
           .toLowerCase()
           .indexOf(token) === 0

--- a/scripts/karma.js
+++ b/scripts/karma.js
@@ -139,7 +139,7 @@ module.exports = robot => {
       userForToken(userToken, response)
         .then(targetUser => {
           if (!targetUser) return
-          if (thisUser.name === getCleanName(targetUser) && op !== '--')
+          if (thisUser.id === targetUser.id && op !== '--')
             return response.send('¡Oe no po, el karma es pa otros no pa ti!')
           if (targetUser.length === '') return response.send('¡Oe no seai pillo, escribe un nombre!')
           const limit = canUpvote(thisUser, targetUser)

--- a/test/karma.test.js
+++ b/test/karma.test.js
@@ -199,7 +199,7 @@ test.cb.serial('No Debe aplicar karma', t => {
   }, 500)
 })
 test.cb.serial('No Debe aplicar karma', t => {
-  t.context.room.user.say('leonardo', 'leonardo++')
+  t.context.room.user.say('leonardo', 'leonardo++', { id: 5 })
   setTimeout(() => {
     t.deepEqual(t.context.room.messages, [
       ['leonardo', 'leonardo++'],
@@ -223,7 +223,7 @@ test.cb.serial('No Debe quitar karma para excepciones explícitas', t => {
   }, 500)
 })
 test.cb.serial('Aplica karma solo si es menos a uno mismo', t => {
-  t.context.room.user.say('ienc', 'ienc--')
+  t.context.room.user.say('ienc', 'ienc--', { id: 10 })
   setTimeout(() => {
     t.deepEqual(t.context.room.messages, [['ienc', 'ienc--'], ['hubot', 'ienc ahora tiene -1 puntos de karma.']])
     t.end()


### PR DESCRIPTION
Arregla detallitos fatales
- Hay un usuario eliminado en la base de datos que mataba el filter
- Ahora usa el id para comparar el usuario que modificar el karma con el target
- Agregar una última linea de defensa si es que el usuario no tiene ni display name o real name (_creo_ que no debería pasar... excepto cuando el usuario está borrado)