### PR TITLE
fix(twitter-feed): url typo

### DIFF
--- a/scripts/twitter.js
+++ b/scripts/twitter.js
@@ -51,7 +51,7 @@ module.exports = function (robot) {
       const id = _get(tweet, 'id_str')
       return {
         title: description,
-        link: `https://twitter.com/${userName}/status/${id}>`
+        link: `https://twitter.com/${userName}/status/${id}`
       }
     }
 


### PR DESCRIPTION
Hay un _typo_ en la URL que hace que los enlaces no funcionen.