### PR TITLE
Se corrige orden de eventos en uoct

### DIFF
--- a/scripts/uoct-golden.js
+++ b/scripts/uoct-golden.js
@@ -70,7 +70,6 @@ const attachmentText = event => `<${event.url}|${event.post_modified}: ${event.p
 const parseEvents = (events, fallback = false) => {
   const parser = fallback ? fallbackText : attachmentText
   return events
-    .sort((firstEvent, secondEvent) => firstEvent.post_modified < secondEvent.post_modified)
     .reduce((text, event) => {
       text += parser(event)
       return text
@@ -137,7 +136,7 @@ module.exports = function (robot) {
           .reduce((/** @type {Array<Event>} */ events, event) => {
             return events.concat(event.data)
           }, [])
-          .sort((firstEvent, secondEvent) => firstEvent.post_modified < secondEvent.post_modified)
+          .sort((firstEvent, secondEvent) => new Date(secondEvent.post_modified) - new Date(firstEvent.post_modified))
       })
       .then(events => {
         if (events.length === 0) {

--- a/test/uoct-golden.test.js
+++ b/test/uoct-golden.test.js
@@ -72,7 +72,7 @@ test('UOCT - restringido para usuarios gold', async t => {
   t.context.room.robot.golden = {
     isGold: () => false
   }
-  t.context.room.user.say('user', 'hubot uoct')
+  await t.context.room.user.say('user', 'hubot uoct')
   await sleep(500)
   t.deepEqual(t.context.room.messages, [['user', 'hubot uoct']])
   t.deepEqual(t.context.postMessage.options.attachments, [
@@ -96,8 +96,9 @@ test('UOCT - cuando no retorna eventos, se responde todo normal', async t => {
     .times(7)
     .reply(200, emptyPayload, { 'content-type': 'text/html; charset=UTF-8' })
 
-  t.context.room.user.say('user', 'hubot uoct')
+  await t.context.room.user.say('user', 'hubot uoct')
   await nockIsDone(scope)
+  await sleep(500)
 
   t.deepEqual(t.context.room.messages, [['user', 'hubot uoct']])
   t.deepEqual(t.context.postMessage.options.attachments, [
@@ -122,9 +123,10 @@ test('UOCT - cuando hay un evento imprime correctamente', async t => {
     .post('/wp/wp-admin/admin-ajax.php', body => body.zone === 'zona-norte')
     .reply(200, payload, { 'content-type': 'text/html; charset=UTF-8' })
 
-  t.context.room.user.say('user', 'hubot uoct')
+  await t.context.room.user.say('user', 'hubot uoct')
   await nockIsDone(scope1)
   await nockIsDone(scope2)
+  await sleep(500)
 
   t.deepEqual(t.context.room.messages, [['user', 'hubot uoct']])
   t.deepEqual(t.context.postMessage.options.attachments, [
@@ -148,8 +150,9 @@ test('UOCT - cuando más de 5, solo muestra 5 ', async t => {
     .times(7)
     .reply(200, payload, { 'content-type': 'text/html; charset=UTF-8' })
 
-  t.context.room.user.say('user', 'hubot uoct')
+  await t.context.room.user.say('user', 'hubot uoct')
   await nockIsDone(scope)
+  await sleep(500)
 
   t.deepEqual(t.context.room.messages, [['user', 'hubot uoct']])
   t.deepEqual(t.context.postMessage.options.attachments, [
@@ -173,8 +176,9 @@ test('UOCT - cuando 404 entrega mensaje de error', async t => {
     .times(7)
     .reply(404)
 
-  t.context.room.user.say('user', 'hubot uoct')
+  await t.context.room.user.say('user', 'hubot uoct')
   await nockIsDone(scope)
+  await sleep(500)
 
   t.deepEqual(t.context.room.messages, [['user', 'hubot uoct']])
   t.deepEqual(t.context.postMessage.options.attachments, [
@@ -196,8 +200,9 @@ test('UOCT - cuando 500 entrega mensaje de error', async t => {
     .times(7)
     .reply(500)
 
-  t.context.room.user.say('user', 'hubot uoct')
+  await t.context.room.user.say('user', 'hubot uoct')
   await nockIsDone(scope)
+  await sleep(500)
 
   t.deepEqual(t.context.room.messages, [['user', 'hubot uoct']])
   t.deepEqual(t.context.postMessage.options.attachments, [


### PR DESCRIPTION
## Descripción
<!--- Proporcione un resumen general de que hace el nuevo script -->

- Se corrige el ordenamiento de los eventos de más nuevos a más viejos.
- Se agrega delay manual (500ms) a los tests para evitar errores random producto de `race condition`.

## Ejemplo de comportamiento
<!---
Proporcione un snippet indicando un ejemplo del comportamiento.
Ejemplo:
```
> hubot my-script
> <salida esperada>
```

Adicionalmente puedes agregar screenshots de como se vera si estas usando attachments.
Para ello puedes usar https://api.slack.com/docs/messages/builder para tener una previsualización.
-->
#### Actual comportamiento
![bug](https://i.imgur.com/az7Gzef.png)
#### Nuevo comportamiento
![bug](https://i.imgur.com/prEE0gu.png)