### PR TITLE
Se renombra plantilla de pull request al por defecto

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,7 @@
----
-name: Nuevo script
-about: Usa esta plantilla para crear PRs de nuevos scripts.
-title: "[new script]: [FEATURE NAME]"
-labels: new script
-assignees: devschile/org
----
-
 ## Descripción
-
 <!--- Proporcione un resumen general de que hace el nuevo script -->
 
 ## Ejemplo de comportamiento
-
 <!---
 Proporcione un snippet indicando un ejemplo del comportamiento.
 Ejemplo:


### PR DESCRIPTION
Buscando mas info de plantillas solo logre dar con que todos los ejemplos usan el nombre por defecto de la plantilla. Lo cual significa que solo es posible usar una sola plantilla ara todos los PRs.

Adicionalmente la cabecera anterior solo es valida para plantillas de issues así que la saque.