### PR TITLE
feat(scripts): add covid19 resume

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -39,6 +39,7 @@ scripts/concurso.js @juanbrujo
 test/concurso.test.js @juanbrujo
 scripts/correos.js @hectorpalmatellez
 test/correos.test.js @hectorpalmatellez
+scripts/covid19.js @lgaticaq
 scripts/dameunaclave.js @quest
 test/dameunaclave.test.js @quest
 scripts/dameunaexcusa.js @juanbrujo

--- a/scripts/covid19.js
+++ b/scripts/covid19.js
@@ -1,0 +1,76 @@
+// Description:
+//  Huemul muestra la cantidad de casos contagiados, recuperados y muertes por el corona virus
+//
+// Dependencies:
+//   None
+//
+// Configuration:
+//   None
+//
+// Commands:
+//   hubot covid19 - Retorna la cantidad de casos de covid19 en Chile.
+//   hubot coronavirus - Retorna la cantidad de casos de covid19 en Chile.
+//
+// Author:
+//   @lgaticaq
+
+module.exports = robot => {
+  robot.respond(/(covid19|coronavirus)$/i, res => {
+    const country = 'Chile'
+    const send = (confirmed, recovered, deaths) => {
+      const fallback = `Hay ${confirmed} casos confirmados, ${recovered} recuperados y ${deaths} muertes en ${country}`
+      if (['SlackBot', 'Room'].includes(robot.adapter.constructor.name)) {
+        const options = {
+          as_user: false,
+          link_names: 1,
+          icon_url: 'https://i.imgur.com/MzMz8ci.png',
+          username: 'Covid 19',
+          unfurl_links: false,
+          attachments: [
+            {
+              fallback,
+              color: 'danger',
+              title: `Resumen de casos confirmados de Covid 19 en ${country}`,
+              fields: [
+                {
+                  title: `${confirmed} :face_with_thermometer:`,
+                  short: true
+                },
+                {
+                  title: `${recovered} :muscle:`,
+                  short: true
+                },
+                {
+                  title: `${deaths} :skull_and_crossbones:`,
+                  short: true
+                }
+              ]
+            }
+          ]
+        }
+        robot.adapter.client.web.chat.postMessage(res.message.room, null, options)
+      } else {
+        res.send(fallback)
+      }
+    }
+
+    const errorMessage = 'Ocurrió un error al hacer la búsqueda'
+
+    robot.http(`https://covid19.mathdro.id/api/countries/${country}`).get()((err, response, body) => {
+      if (err) {
+        robot.emit('error', err, res, 'covid19')
+        robot.emit('slack.ephemeral', errorMessage, res.message.room, res.message.user.id)
+      } else if (response.statusCode !== 200) {
+        robot.emit('slack.ephemeral', errorMessage, res.message.room, res.message.user.id)
+      } else {
+        try {
+          const data = JSON.parse(body)
+          send(data.confirmed.value, data.recovered.value, data.deaths.value)
+        } catch (err) {
+          robot.emit('error', err, res, 'covid19')
+          robot.emit('slack.ephemeral', errorMessage, res.message.room, res.message.user.id)
+        }
+      }
+    })
+  })
+}


### PR DESCRIPTION
## Descripción
<!--- Proporcione un resumen general de que hace el nuevo script -->
Se agrega script que entrega la cantidad de casos confirmados, recuperados y muertes por el corona virus en Chile.

@hectorpalmatellez++ por el link de la api.

## Ejemplo de comportamiento
<!---
Proporcione un snippet indicando un ejemplo del comportamiento.
Ejemplo:
```
> hubot my-script
> <salida esperada>
```

Adicionalmente puedes agregar screenshots de como se vera si estas usando attachments.
Para ello puedes usar https://api.slack.com/docs/messages/builder para tener una previsualización.
-->

CLI
```
> huemul coronavirus
> Hay 43 casos confirmados, 0 recuperados y 0 muertes en Chile
```

Slack
![](https://i.imgur.com/3rZqThB.png)