### PR TITLE
HOTFIX(poll.js): Status messages are now ephemeral

### DIFF
--- a/scripts/poll.js
+++ b/scripts/poll.js
@@ -32,7 +32,7 @@ const uuid = function b (a) {
 }
 
 module.exports = bot => {
-  const debug = true
+  const debug = false
 
   const MINUTE_IN_MS = 60 * 1e3
 

--- a/scripts/poll.js
+++ b/scripts/poll.js
@@ -530,10 +530,6 @@ module.exports = bot => {
       ts: ts
     })
     return handleStatusMessage(pollId, TXT_POLL_REMOVED_SUCCESSFULLY, userId, channel)
-    // return web.chat.postMessage({
-    //   channel: channel,
-    //   text: TXT_POLL_REMOVED_SUCCESSFULLY
-    // })
   }
 
   // Handlers
@@ -626,24 +622,12 @@ module.exports = bot => {
           await handleRefreshPoll(pollId)
 
           return handleStatusMessage(pollId, TXT_VOTE_SUCCESSFUL, userId, channelId)
-          // return web.chat.postMessage({
-          //   channel: channelId,
-          //   text: TXT_VOTE_SUCCESSFUL
-          // })
         }
       } else {
         return handleStatusMessage(pollId, TXT_VOTE_CANT, userId, channelId)
-        // return web.chat.postMessage({
-        //   channel: channelId,
-        //   text: TXT_VOTE_CANT
-        // })
       }
     }
     return handleStatusMessage(pollId, TXT_VOTE_ERROR, userId, channelId)
-    // return web.chat.postMessage({
-    //   channel: channelId,
-    //   text: TXT_VOTE_ERROR
-    // })
   }
 
   const handleFinishPoll = payload => {
@@ -686,10 +670,6 @@ module.exports = bot => {
         }
       } else {
         return handleStatusMessage(pollId, TXT_POLL_REMOVED_NO_PERMISSION, userId, channelId)
-        // return web.chat.postMessage({
-        //   channel: channelId,
-        //   text: TXT_POLL_REMOVED_NO_PERMISSION
-        // })
       }
     } else if (author === username) {
       // Find TS of the message somewhere because of the poll not existing in memory.


### PR DESCRIPTION
## Descripción
Status messages are now ephemeral so as to not clutter the  channel with errors. 

## Ejemplo de comportamiento
<!---
Proporcione un snippet indicando un ejemplo del comportamiento.
Ejemplo:
```
> hubot my-script
> <salida esperada>
```

Adicionalmente puedes agregar screenshots de como se vera si estas usando attachments.
Para ello puedes usar https://api.slack.com/docs/messages/builder para tener una previsualización.
-->
