### PR TITLE
fix(js): summertime starts sunday am, not saturday pm

### DIFF
--- a/scripts/horario-verano.js
+++ b/scripts/horario-verano.js
@@ -23,10 +23,10 @@ module.exports = robot => {
 
     if (what === 'inicio') {
       date = moment([year, monthBegin])
-      msg.send(`:alarm_clock: El horario de verano este ${year} comienza el sábado ${date.day(+6).format('DD-MM-YYYY')}.`)
+      msg.send(`:alarm_clock: El horario de verano este ${year} comienza el domingo ${date.day(+7).format('DD-MM-YYYY')} a las 00:00hrs.`)
     } else if (what === 'fin') {
       date = moment([year, monthEnd])
-      msg.send(`:alarm_clock: El horario de verano este ${year} termina el sábado ${date.day(+6).format('DD-MM-YYYY')}.`)
+      msg.send(`:alarm_clock: El horario de verano este ${year} termina el domingo ${date.day(+7).format('DD-MM-YYYY')} a las 00:00hrs.`)
     } else {
       msg.send(':alarm_clock: Debes elegir si quieres saber el *inicio* o *fin* del horario de verano')
     }

--- a/scripts/temblor.js
+++ b/scripts/temblor.js
@@ -72,9 +72,7 @@ module.exports = robot => {
               },
               {
                 title: 'Fecha',
-                value: new Date(time)
-                  .toISOString()
-                  .replace(/(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2}).\d+Z/, '$1 $2 UTC'),
+                value: new Date(time).toString(),
                 short: true
               }
             ]


### PR DESCRIPTION
test: 
```
huemul> huemul horario verano inicio
huemul> :alarm_clock: El horario de verano este 2020 comienza el domingo 06-09-2020 a las 00:00hrs.
```

test:
```
huemul> huemul temblores costa rica
huemul>
M 6.0 - 3 km ESE of Jacó, Costa Rica: 
- Lugar: 3 km ESE of Jacó, Costa Rica 
- Magnitud: 6 (richter) 
- Fecha/Hora: Mon Aug 24 2020 18:51:10 GMT-0300 (Chile Summer Time) 
- Enlace: https://earthquake.usgs.gov/earthquakes/eventpage/us7000bcbv
```
