### PR TITLE
fix(js): change query domain to search jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ El repositorio queda abierto para todos los miembros de [devsChile en GitHub](ht
 
 ## Stickers
 
-Nuestro bot es tan querido que imprimimos _stickers_ y se venden a módicos precios y modalidades. Llévate tus 3 stickers a través del Paypal en [el sitio de devsChile](http://www.devschile.cl)
+Nuestro bot es tan querido que tenemos _swags_ los que están disponibles en [la tienda devsChile](https://tienda.devschile.cl)
 
-![Stickers huemul](http://i.imgur.com/KfAx4Mx.jpg)
+![Swags huemul](https://i.imgur.com/aNEtsHa.jpg)

--- a/scripts/pegas.js
+++ b/scripts/pegas.js
@@ -17,7 +17,7 @@ module.exports = function (robot) {
   robot.respond(/(pega|pegas|trabajo|trabajos) (.*)/i, function (msg) {
     msg.send('Buscando en GetOnBrd... :dev:')
 
-    const domain = 'https://www.getonbrd.cl/empleos-'
+    const domain = 'https://www.getonbrd.com/jobs-'
     const busqueda = msg.match[2]
     const url = domain + querystring.escape(busqueda)
 
@@ -39,12 +39,8 @@ module.exports = function (robot) {
             return this.type === 'text'
           })
           .text()
-        const type = $(this)
-          .find('.gb-results-list__title .color-hierarchy3')
-          .text()
-        const path = $(this)
-          .find('a')
-          .attr('href')
+        const type = $(this).find('.gb-results-list__title .color-hierarchy3').text()
+        const path = $(this).find('a').attr('href')
 
         resultados.push(`<${path}|${title} - ${type}>`)
       })

--- a/test/pegas.test.js
+++ b/test/pegas.test.js
@@ -5,17 +5,17 @@ import path from 'path'
 import nock from 'nock'
 
 const helper = new Helper('../scripts/pegas.js')
-const sleep = m => new Promise(resolve => setTimeout(() => resolve(), m))
+const sleep = (m) => new Promise((resolve) => setTimeout(() => resolve(), m))
 
-test.beforeEach(t => {
+test.beforeEach((t) => {
   t.context.room = helper.createRoom({ httpd: false })
 })
 
-test.afterEach(t => t.context.room.destroy())
+test.afterEach((t) => t.context.room.destroy())
 
-test('Buscando pega fullstack', async t => {
-  nock('https://www.getonbrd.cl')
-    .get('/empleos-fullstack')
+test('Buscando pega fullstack', async (t) => {
+  nock('https://www.getonbrd.com')
+    .get('/jobs-fullstack')
     .replyWithFile(200, path.join(__dirname, 'html', 'pegas-200.html'))
   t.context.room.user.say('user', 'hubot pega fullstack')
   await sleep(500)
@@ -29,13 +29,14 @@ test('Buscando pega fullstack', async t => {
 
   // test response messages of hubot
   t.deepEqual(hubotMessage1, ['hubot', 'Buscando en GetOnBrd... :dev:'])
-  t.deepEqual(hubotMessage2, ['hubot', 'Se ha encontrado 1 resultado para *fullstack*:\n1: </empleos/programacion/programador-fullstack-wivo-analytics| - >\n'])
+  t.deepEqual(hubotMessage2, [
+    'hubot',
+    'Se ha encontrado 1 resultado para *fullstack*:\n1: </empleos/programacion/programador-fullstack-wivo-analytics| - >\n'
+  ])
 })
 
-test('Redirect', async t => {
-  nock('https://www.getonbrd.cl')
-    .get('/empleos-301')
-    .reply(301)
+test('Redirect', async (t) => {
+  nock('https://www.getonbrd.com').get('/jobs-301').reply(301)
   t.context.room.user.say('user', 'hubot pega 301')
   await sleep(500)
 


### PR DESCRIPTION
## Descripción
Fix de script ya que getonbrd cambio de `.cl` a `.com` y de `empleos-` a `jobs-`, se asen internacionales.

## Ejemplo de comportamiento
```
> huemul pegas junior
Buscando en GetOnBrd... :dev:
Se han encontrado 150 resultados para *junior*:
1: <https://www.getonbrd.com/jobs/programming/ingeniero-en-desarrollo-react-tcit-santiago|Ingeniero Node.js React (Junior) - Full time>
2: <https://www.getonbrd.com/jobs/mobile-developer/ios-mobile-software-engineer-modernizing-medicine-santiago|iOS Mobile Software Engineer - Full time>
3: <https://www.getonbrd.com/jobs/design-ux/disenador-ux-leytonmedia-santiago|Diseñador(a) UX - Full time>
4: <https://www.getonbrd.com/jobs/programming/technical-lead-shopify-denda-santiago|Desarrollador en Shopify - Full time>
5: <https://www.getonbrd.com/jobs/programming/full-stack-developer-mystrengthbook-remote-4ec1|Junior Full-Stack Developer - Full time>
Más resultados en: <https://www.getonbrd.com/jobs-junior|getonbrd>
```

![Screen Shot 2020-10-10 at 10 22 03 PM](https://user-images.githubusercontent.com/362186/95668199-089ca800-0b47-11eb-9fcb-36bd14fa52e1.png)

Fixes https://github.com/devschile/huemul/issues/636

