### PR TITLE
Script que pide definción de palabra desde la RAE

### DIFF
--- a/scripts/rae.js
+++ b/scripts/rae.js
@@ -1,0 +1,31 @@
+// Description:
+//  Devuelve una definición de la palabra desde la página de la Real Academia Española (RAE)
+//
+// Commands:
+//  hubot rae|define <palabra>
+//
+// Author:
+//  @fskarmeta
+
+  
+const cheerio = require('cheerio')
+const fetch = require('node-fetch')
+
+module.exports = function (robot) {
+  robot.respond(/(rae|define) (\s*[a-zA-ZÀ-ÿ]*)/i, function (msg) {
+    const url = 'http://dle.rae.es/srv/search?w='
+    const word = encodeURI(msg.match[2])
+    const fetchQuery = url + word
+    fetch(fetchQuery)
+    .then(res => res.text())
+    .then(text => {
+        $ = cheerio.load(text)
+        const definition = $('meta[name="description"]').attr('content')
+        if (definition.split(" ")[0] == "Versión") {
+            msg.send("No se encontró aquella palabra :sadhuemul:")
+        } else {
+        msg.send(definition)
+        }
+    }).catch(e => msg.send("Ohh no, algo no esta funcionando bien. ¿Conocen algun programador que pueda ver esto? :kappa:"))
+  })
+}

--- a/scripts/rae.js
+++ b/scripts/rae.js
@@ -19,7 +19,7 @@ module.exports = function (robot) {
     fetch(fetchQuery)
     .then(res => res.text())
     .then(text => {
-        $ = cheerio.load(text)
+        const $ = cheerio.load(text)
         const definition = $('meta[name="description"]').attr('content')
         if (definition.split(" ")[0] == "Versión") {
             msg.send("No se encontró aquella palabra :sadhuemul:")

--- a/scripts/rae.js
+++ b/scripts/rae.js
@@ -10,22 +10,36 @@
   
 const cheerio = require('cheerio')
 const fetch = require('node-fetch')
+const querystring = require('querystring')
 
 module.exports = function (robot) {
-  robot.respond(/(rae|define) (\s*[a-zA-ZÀ-ÿ]*)/i, function (msg) {
+  robot.respond(/(rae|define) (\s*[a-zA-ZÀ-ÿ]*)(\s*[a-zA-ZÀ-ÿ]*)/i, function (msg) {
+
+
+    let word = msg.match[2].trim()
+
+    if (msg.match[3]) {
+      word += msg.match[3].trim()
+    }
+
+    const search = querystring.escape(word.toLowerCase())
+
     const url = 'http://dle.rae.es/srv/search?w='
-    const word = encodeURI(msg.match[2])
-    const fetchQuery = url + word
+    const fetchQuery = url + search
     fetch(fetchQuery)
     .then(res => res.text())
     .then(text => {
+
         const $ = cheerio.load(text)
         const definition = $('meta[name="description"]').attr('content')
-        if (definition.split(" ")[0] == "Versión") {
+
+        if (definition.split(" ")[0] === "Versión") {
             msg.send("No se encontró aquella palabra :sadhuemul:")
         } else {
         msg.send(definition)
         }
-    }).catch(e => msg.send("Ohh no, algo no esta funcionando bien. ¿Conocen algun programador que pueda ver esto? :kappa:"))
+
+    }).catch(e => msg.send("Ohh no, algo no está funcionando bien. ¿Conocen algún programador que pueda ver esto? :kappa:"))
   })
+  
 }

--- a/scripts/rae.js
+++ b/scripts/rae.js
@@ -14,32 +14,21 @@ const querystring = require('querystring')
 
 module.exports = function (robot) {
   robot.respond(/(rae|define) (\s*[a-zA-ZÀ-ÿ]*)(\s*[a-zA-ZÀ-ÿ]*)/i, function (msg) {
-
-
-    let word = msg.match[2].trim()
-
-    if (msg.match[3]) {
-      word += msg.match[3].trim()
-    }
-
+    const word = msg.match[3] ? msg.match[2].trim() + msg.match[3].trim() : msg.match[2].trim()
     const search = querystring.escape(word.toLowerCase())
-
     const url = 'http://dle.rae.es/srv/search?w='
     const fetchQuery = url + search
     fetch(fetchQuery)
     .then(res => res.text())
     .then(text => {
-
         const $ = cheerio.load(text)
         const definition = $('meta[name="description"]').attr('content')
-
         if (definition.split(" ")[0] === "Versión") {
             msg.send("No se encontró aquella palabra :sadhuemul:")
         } else {
-        msg.send(definition)
+            msg.send(definition)
         }
-
-    }).catch(e => msg.send("Ohh no, algo no está funcionando bien. ¿Conocen algún programador que pueda ver esto? :kappa:"))
+    }).catch(e => msg.send("Ohh no, algo no está funcionando bien. ¿Conocen algún programador que pueda ver esto? :huemul-patitas:"))
   })
   
 }


### PR DESCRIPTION
## Descripción
La RAE no tiene API oficial para solicitar la definición de una palabra, tampóco encontré alguna otra API que haga esto.
Este script usa la URL pública para buscar una palabra en su página `https://dle.rae.es/srv/search?w=palabra` y con la ayuda de cheerio extrae el contenido de la defincion de un meta tag del html.

Cuando no se ha encontrado palabra el mismo web scrap devuelve siempre el mismo contenido:
`Versión electrónica 23.4 del «Diccionario de la lengua española», obra lexicográfica académica por excelencia.`
Por lo que usé la primera palabra `Versión` como indicador para una palabra no existente o incorrecta.

Se uso node-fetch en vez del robot http request. Si esto es problemático puedo intentar cambiarlo.

## Ejemplo de comportamiento

Comandos: define|rae

@Huemul define extravagante
`1. adj. Que se hace o dice fuera del orden o común modo de obrar. 2. adj. Raro, extraño, desacostumbrado, excesivamente peculiar u original.`

@Huemul rae entusiasmo
`1. m. Exaltación y fogosidad del ánimo, excitado por algo que lo admire o cautive. 2. m. Adhesión fervorosa que mueve a favorecer una causa o empeño.`

@Huemul define asdadasd
`No se encontró aquella palabra :sadhuemul:`
