### PR TITLE
ci: add github actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,28 @@
+name: Node.js CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '10'
+          cache: 'yarn'
+      - run: yarn install
+      - run: yarn test
+        env:
+          TZ: America/Santiago
+  deploy:
+    if: github.ref == 'refs/heads/master'
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: ssh deploy
+        uses: dokku/github-action@master
+        with:
+          git_remote_url: 'ssh://dokku@devschile.cl/huemul'
+          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
## Descripción
<!--- Proporcione un resumen general de que hace el nuevo script -->
Se agrega `.github/workflow/nodejs.yml` con la integracion de github actions. Este tiene dos jobs. El primero es test, el cual instala las dependencias usando yarn y luego ejecuta el test.

Y el segundo job es el deploy a dokku. Este solo ocurre si el job esta corriendo en la rama master.

Técnicamente es lo mismo que se hace en travis, aunque no he podido testearlo funcionando. Así que idealmente revisen bien y el que tenga acceso a dokku podría testear de forma controlada en una rama para ver si funciona como se espera.

Para que esto funcione es necesario agregar un secret al repo de huemul con el contenido de la clave ssh privada para poder hacer el deploy a dokku.

Pueden revisar la action de dokku en  detalle en https://github.com/dokku/github-action.

## Ejemplo de comportamiento
<!---
Proporcione un snippet indicando un ejemplo del comportamiento.
Ejemplo:
```
> hubot my-script
> <salida esperada>
```

Adicionalmente puedes agregar screenshots de como se vera si estas usando attachments.
Para ello puedes usar https://api.slack.com/docs/messages/builder para tener una previsualización.
-->
N.A.