### PR TITLE
feat(justwatch): include justwatch-api interaction to check providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "hubot-wikipedia-lang": "1.0.3",
     "hubot-youtube": "1.1.0",
     "jquery": "3.5.0",
+    "justwatch-api": "^1.0.7",
     "mathjs": "7.5.1",
     "md-2-json": "^1.0.5",
     "moment": "2.22.1",

--- a/scripts/justwatch.js
+++ b/scripts/justwatch.js
@@ -1,0 +1,87 @@
+// Description:
+//   Obtiene proveedores y URL de justwatch de servicio para ver la peli / serie
+//
+// Dependencies:
+//   None
+//
+// Commands:
+//   hubot donde ver <NOMBRE>
+//
+// Author:
+//   @joseglego
+
+const JustWatch = require('justwatch-api')
+
+// Providers List is just a key:value with `id` and `clear_name`.
+// Why?
+//   - Avoid doing n times for semi static data.
+//   - Fastests
+//   - Not official API. So, not overcrow
+// More Info: https://www.npmjs.com/package/justwatch-api
+// Got with: `jw.getProviders()`
+const providers = {
+  2: 'Apple iTunes',
+  3: 'Google Play Movies',
+  8: 'Netflix',
+  11: 'Mubi',
+  31: 'HBO Go',
+  43: 'Starz',
+  67: 'Blim',
+  119: 'Amazon Prime Video',
+  167: 'Claro video',
+  190: 'Curiosity Stream',
+  269: 'Funimation Now',
+  274: 'QubitTV',
+  283: 'Crunchyroll',
+  300: 'Pluto TV',
+  315: 'Hoichoi',
+  337: 'Disney Plus',
+  339: 'Movistar Play',
+  350: 'Apple TV Plus',
+  384: 'HBO Max',
+  444: 'Dekkoo',
+  464: 'Kocowa',
+  467: 'DIRECTV GO',
+  475: 'DOCSVILLE',
+  521: 'Spamflix',
+  531: 'Paramount Plus',
+  546: 'WOW Presents Plus',
+  551: 'Magellan TV',
+  554: 'BroadwayHD',
+  559: 'Filmzie',
+  567: 'True Story',
+  569: 'DocAlliance Films',
+  575: 'KoreaOnDemand',
+  619: 'Star Plus',
+  677: 'Eventive',
+  692: 'Cultpix',
+  701: 'FilmBox+',
+  1771: 'Takflix'
+}
+
+const url = 'https://www.justwatch.com'
+const locale = 'es_CL'
+
+module.exports = robot => {
+  robot.respond(/donde ver (.*)/i, async res => {
+    const jw = new JustWatch({ locale })
+
+    const toSearch = res.match[1]
+    const response = await jw.search(toSearch)
+    let message = ''
+
+    if (response?.items.length) {
+      const item = response.items[0]
+      const offers = Array.from(new Set(item.offers?.map(offer => offer.provider_id) || [])).map(providerId => providers[providerId])
+      const availabilityMessage =
+        offers.length
+        ? `Puedes ver ${item.title} en: ${offers.join(', ')}`
+          : `Actualmente, NO hay opciones para ver ${item.title} en Chile`
+
+      message = [availabilityMessage, `Puedes ver más info en la página de JustWatch: ${url + item.full_path}`].join('\n')
+    } else {
+      message = `No he podido encontrar sugerencia para ${toSearch}. Intenta alguna variación u otro nombre.`
+    }
+    return res.send(message)
+  })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5745,6 +5745,11 @@ just-extend@^4.0.2:
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.2.1.tgz#ef5e589afb61e5d66b24eca749409a8939a8c744"
   integrity sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==
 
+justwatch-api@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/justwatch-api/-/justwatch-api-1.0.7.tgz#4573436b3ae86c1ce4a089e6e153898ae0e4e569"
+  integrity sha512-Tg3aP6jSzUv7UMQKVmDi/MnXzUr6/DzNWfOmoi7UEQPQu/roLMaaG+xY9erP1afcTRzZW6p8mgvOdWi8Ifj8xQ==
+
 kew@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/kew/-/kew-0.7.0.tgz#79d93d2d33363d6fdd2970b335d9141ad591d79b"


### PR DESCRIPTION
## Descripción
Permite saber el proveedor y acceder a más info en la página de JustWatch
Resuleve: https://github.com/devschile/huemul/issues/707
## Ejemplo de comportamiento
```
// TV Show Found  
huemul> huemul donde ver mr robot
huemul> Puedes ver Mr. Robot en: Amazon Prime Video, Movistar Play
Puedes ver más info en la página de JustWatch: https://www.justwatch.com/cl/serie/mr-robot

// Movie Found
huemul> huemul donde ver la comunidad del anillo
huemul> Puedes ver El señor de los anillos: La comunidad del anillo en: Apple iTunes, Google Play Movies, HBO Go, Amazon Prime Video, Movistar Play, HBO Max
Puedes ver más info en la página de JustWatch: https://www.justwatch.com/cl/pelicula/el-senor-de-los-anillos-la-comunidad-del-anillo

// No found
huemul> huemul donde ver dhamer
huemul> No he podido encontrar sugerencia para dhamer. Intenta alguna variación u otro nombre.
```
