### PR TITLE
feat(discord): retorna el link a discord de devschile

### DIFF
--- a/scripts/discord.js
+++ b/scripts/discord.js
@@ -1,0 +1,12 @@
+// Description:
+//  Devuelve el link al canal de devsChile en discord
+//
+// Commands:
+//  hubot discord
+//
+// Author:
+//  @fskarmeta
+
+const discordLink = "https://discord.gg/dKmPnpu5rY"
+
+module.exports = robot => robot.respond(/discord/gi, msg => msg.send(`Aquí tienes el link al discord de devsChile: ${discordLink}`));

--- a/test/discord.test.js
+++ b/test/discord.test.js
@@ -1,0 +1,16 @@
+import 'coffee-script/register'
+import Helper from 'hubot-test-helper'
+import test from 'ava'
+
+const helper = new Helper('../scripts/discord.js')
+const sleep = m => new Promise(resolve => setTimeout(() => resolve(), m))
+
+
+test('Devuelve string con el link al discord de devsChile', async t => {
+  t.context.room = helper.createRoom({ httpd: false })
+  t.context.room.user.say('user', 'hubot discord')
+  await sleep(500)
+  const hubotResponse = t.context.room.messages[1][1]
+  t.true(hubotResponse.includes('https://discord.gg/'))
+  t.context.room.destroy()
+})


### PR DESCRIPTION
## Descripción
Retorna el link al discord de devs chile con un link que no expira. 

## Ejemplo de comportamiento

Proporcione un snippet indicando un ejemplo del comportamiento.
Ejemplo:
```
> huemul discord
> Aquí tienes el link al discord de devsChile: https://discord.gg/dKmPnpu5rY
```
