### PR TITLE
feat(gardel): add custom payday option

### DIFF
--- a/scripts/gardel.js
+++ b/scripts/gardel.js
@@ -1,5 +1,5 @@
 // Description:
-//   TODO
+//   Return pay day in current month
 //
 // Dependencies:
 //   moment-business-days
@@ -8,7 +8,8 @@
 //   None
 //
 // Commands:
-//   hubot gardel|cuando pagan|cuándo pagan - Indica la cantidad de dias que faltan para que paguen
+//   hubot gardel|cu[á|a]ndo pagan - Indica la cantidad de dias que faltan para que paguen
+//   hubot gardel|cu[á|a]ndo pagan <param> - Indica cuántos días faltan para la fecha de pago elegida
 //
 // Author:
 //   @hectorpalmatellez
@@ -23,15 +24,16 @@ module.exports = function gardel (robot) {
   robot.respond(/gardel|cu[aá]ndo pagan(.*)/i, function (msg) {
     const today = moment(`${moment().format('YYYY-MM-DD')}T00:00:00-04:00`)
     const param = parseInt(msg.message.text.split(' ')[2], 10)
-    const isItOver = moment(`${moment().format('YYYY-MM')}-${param}`) < today
-    const paramDate = moment(`${moment().format('YYYY-MM')}-${param}`)
-    const lastBusinessDayMoment = param ? isItOver ? paramDate.add(1, 'month') : paramDate : moment()
+    const formattedParamDate = moment(`${moment().format('YYYY-MM')}-${param}`)
+    const dateWithParam = formattedParamDate > today ? formattedParamDate : formattedParamDate.add(1, 'month')
+    const endOfBusinessDay = moment()
       .endOf('month')
       .isBusinessDay()
       ? moment().endOf('month')
       : moment()
         .endOf('month')
         .prevBusinessDay()
+    const lastBusinessDayMoment = param ? dateWithParam : endOfBusinessDay
     const dateLastBusinessDay = lastBusinessDayMoment.format('YYYY-MM-DD')
     const lastBusinessDay = moment(`${dateLastBusinessDay}T00:00:00-04:00`)
     const dayMessage = moment.duration(lastBusinessDay.diff(today)).humanize()

--- a/scripts/gardel.js
+++ b/scripts/gardel.js
@@ -13,28 +13,31 @@
 // Author:
 //   @hectorpalmatellez
 
-var moment = require('moment-business-days')
+const moment = require('moment-business-days')
 
 module.exports = function gardel (robot) {
   'use strict'
 
   moment.locale('es')
 
-  robot.respond(/gardel|cu[aá]ndo pagan/i, function (msg) {
-    var today = moment(`${moment().format('YYYY-MM-DD')}T00:00:00-04:00`)
-    var lastBusinessDayMoment = moment()
+  robot.respond(/gardel|cu[aá]ndo pagan(.*)/i, function (msg) {
+    const today = moment(`${moment().format('YYYY-MM-DD')}T00:00:00-04:00`)
+    const param = parseInt(msg.message.text.split(' ')[2], 10)
+    const isItOver = moment(`${moment().format('YYYY-MM')}-${param}`) < today
+    const paramDate = moment(`${moment().format('YYYY-MM')}-${param}`)
+    const lastBusinessDayMoment = param ? isItOver ? paramDate.add(1, 'month') : paramDate : moment()
       .endOf('month')
       .isBusinessDay()
       ? moment().endOf('month')
       : moment()
         .endOf('month')
         .prevBusinessDay()
-    var dateLastBusinessDay = lastBusinessDayMoment.format('YYYY-MM-DD')
-    var lastBusinessDay = moment(`${dateLastBusinessDay}T00:00:00-04:00`)
-    var dayMessage = moment.duration(lastBusinessDay.diff(today)).humanize()
-    var dayCount = lastBusinessDay.diff(today, 'days')
-    var message = ''
-    var plural = dayCount > 1 ? 'n' : ''
+    const dateLastBusinessDay = lastBusinessDayMoment.format('YYYY-MM-DD')
+    const lastBusinessDay = moment(`${dateLastBusinessDay}T00:00:00-04:00`)
+    const dayMessage = moment.duration(lastBusinessDay.diff(today)).humanize()
+    const dayCount = lastBusinessDay.diff(today, 'days')
+    let message = ''
+    const plural = dayCount > 1 ? 'n' : ''
 
     if (dayCount === 0) {
       message = ':tada: Hoy pagan :tada:'


### PR DESCRIPTION
## Descripción
Agrega opción de definir un día específico como día de pago, reemplazando la lógica de `último día hábil del mes`. Si este día definido cae en finde: mala suerte.

## Ejemplo de comportamiento
Día definido que ya pasó.
<img width="646" alt="image" src="https://user-images.githubusercontent.com/1266785/212745462-c00e7295-ac2d-415e-85e5-bc9db8b13663.png">
<img width="632" alt="image" src="https://user-images.githubusercontent.com/1266785/212745507-d198bf93-24de-4bb4-9a7d-e00bf7ed8560.png">
Día definido en el futuro
<img width="633" alt="image" src="https://user-images.githubusercontent.com/1266785/212745598-ba1aa20f-fd36-49fd-87e4-80f644aaa282.png">

