### PR TITLE
fix(cumple): use display name (nickname) instead of real username

### DIFF
--- a/scripts/cumpleaños.js
+++ b/scripts/cumpleaños.js
@@ -46,6 +46,9 @@ const isValidDate = (day, month) => {
   return day >= 1 && day <= daysInMonth
 }
 
+const getDisplayName = user =>
+  (user.slack && user.slack.profile && user.slack.profile.display_name) || user.name
+
 module.exports = robot => {
   let channelId = null
 
@@ -63,8 +66,9 @@ module.exports = robot => {
     if (!isValidDate(day, month)) {
       return msg.send(`La fecha ${day}/${month} no es válida.`)
     }
+    const nickname = getDisplayName(msg.message.user)
     const birthdays = JSON.parse(robot.brain.get('birthdays') || '{}')
-    birthdays[msg.message.user.name] = { user: msg.message.user.name, day, month }
+    birthdays[msg.message.user.name] = { user: nickname, day, month }
     robot.brain.set('birthdays', JSON.stringify(birthdays))
     robot.brain.save()
     msg.send(`Listo, registré tu cumpleaños el ${day}/${month} 🎂`)


### PR DESCRIPTION
## Summary
- The birthday script was storing and displaying `msg.message.user.name` (the real Slack username) instead of the user's display name/nickname
- Added a `getDisplayName` helper that reads `user.slack.profile.display_name` with a fallback to `user.name`, following the same pattern used in `poll.js`
- The brain key still uses the real username for stable lookups; only the displayed `user` field uses the nickname

## Test plan
- [ ] Run `huemul cumple set DD/MM` and confirm the confirmation message and subsequent `hoy`/`mes`/`lista` outputs show the nickname, not the real username
- [ ] Confirm `huemul cumple delete` still removes the correct entry
- [ ] Existing unit tests pass (fallback to `.name` applies in test environments where `user.slack` is undefined)

🤖 Generated with [Claude Code](https://claude.com/claude-code)