### PR TITLE
Refactor tiempo.js for better weather response

### DIFF
--- a/scripts/tiempo.js
+++ b/scripts/tiempo.js
@@ -1,6 +1,5 @@
 // Description:
-//   Obtiene info del tiempo desde donde el usuario haga la consulta, la manda
-//   a Wttr.in y muestra el resultado en Slack.
+//   Obtiene info del tiempo desde wttr.in y muestra solo las condiciones actuales.
 //
 // Dependencies:
 //   None
@@ -17,24 +16,26 @@ module.exports = robot => {
     const defaultCity = 'Santiago, Chile'
     let city = msg.match[2].trim() || defaultCity
 
-    // Si ciudad ingresada es S|santiago, retorna a: Santiago, Chile
     city = city.toLowerCase() === 'santiago' ? defaultCity : city
 
     robot
-      .http(`http://wttr.in/${city}?m`)
+      .http(`https://wttr.in/${encodeURIComponent(city)}?m&T`)
       .header('Accept', '*/*')
       .header('User-Agent', 'curl/7.43.0')
       .get()((err, res, body) => {
-        if (err || res.statusCode !== 200 || body === 'ERROR' || /sorry/gi.test(body)) {
+        if (err || res.statusCode !== 200 || !body || /sorry/gi.test(body)) {
           if (err) robot.emit('error', err, msg, 'tiempo')
           return msg.reply('ocurrió un error con la búsqueda')
         }
-        const raw = body.split('\n')
-        const idx = raw.findIndex(el => /\s+┌─────────────┐\s+/.test(el))
-        const result = raw
-          .slice(0, idx)
-          .map(text => text.replace(/\[(\d+)?((;\d+)+)?(m)?/g, ''))
+
+        const lines = body.split('\n')
+        // Cortar justo antes de las tablas de forecast
+        const forecastIdx = lines.findIndex(line => line.includes('┌─────────────┐'))
+        const result = (forecastIdx === -1 ? lines : lines.slice(0, forecastIdx))
           .join('\n')
+          .replace(/\x1b\[[0-9;]*m/g, '')  // limpiar códigos ANSI por si acaso
+          .trimEnd()
+
         msg.send('```' + result + '```')
       })
   })


### PR DESCRIPTION
This pull request updates the `scripts/tiempo.js` script to improve how weather information is fetched and displayed. The main focus is on showing only the current weather conditions from wttr.in, cleaning up the output, and improving reliability.

**Weather data fetching and output improvements:**

* The script now fetches weather data using `https` and encodes the city name to handle special characters, ensuring more reliable API requests. (`scripts/tiempo.js`, [scripts/tiempo.jsL20-R38](diffhunk://#diff-d8e236db0ec44343e60676891417964ee41a08acd363a3f6f0959c21b35978ebL20-R38))
* The query to wttr.in now includes the `&T` parameter to limit the output to current conditions only, instead of a full forecast. (`scripts/tiempo.js`, [scripts/tiempo.jsL20-R38](diffhunk://#diff-d8e236db0ec44343e60676891417964ee41a08acd363a3f6f0959c21b35978ebL20-R38))
* The script cleans up the output by removing ANSI color codes and trimming unnecessary lines, making the weather report easier to read in Slack. (`scripts/tiempo.js`, [scripts/tiempo.jsL20-R38](diffhunk://#diff-d8e236db0ec44343e60676891417964ee41a08acd363a3f6f0959c21b35978ebL20-R38))

**Error handling improvements:**

* The script now checks for empty responses and handles errors more robustly when fetching weather data. (`scripts/tiempo.js`, [scripts/tiempo.jsL20-R38](diffhunk://#diff-d8e236db0ec44343e60676891417964ee41a08acd363a3f6f0959c21b35978ebL20-R38))

**Documentation update:**

* The description at the top of the file has been updated to reflect that only current conditions are shown. (`scripts/tiempo.js`, [scripts/tiempo.jsL2-R2](diffhunk://#diff-d8e236db0ec44343e60676891417964ee41a08acd363a3f6f0959c21b35978ebL2-R2))Updated weather fetching logic to improve error handling and response formatting.

## Descripción
Fixed, ahora retorna bien el clima actual

## Ejemplo de comportamiento

```
> huemul clima
Weather report: Santiago, Chile

                Overcast
       .--.     +14(15) °C
    .-(    ).   ↖ 4 km/h
   (___.__)__)  10 km
                0.3 mm
```
