### PR TITLE
fix(horoscopo): migrar a horoscopo.devschile.cl y persona Pedrito Engel

### DIFF
--- a/scripts/horoscopo.js
+++ b/scripts/horoscopo.js
@@ -2,10 +2,10 @@
 //   Muestra el horóscopo del día según el signo
 //
 // Dependencies:
-//   https://api.xor.cl/tyaas/
+//   https://horoscopo.devschile.cl/api/horoscopo
 //
 // Configuration:
-//   None
+//   HOROSCOPO_API_KEY - API key requerida por horoscopo.devschile.cl (ver README del proyecto)
 //
 // Commands:
 //   hubot horóscopo <signo zodiacal> - Muestra el horóscopo del día para el signo indicado. Ejemplo: `hubot horóscopo leo`
@@ -14,24 +14,89 @@
 // Author:
 //   @jorgeepunan
 
-const url = 'https://api.xor.cl/tyaas/'
+'use strict'
+
+const url = 'https://horoscopo.devschile.cl/api/horoscopo'
+
+// Lista solo para el mensaje de ayuda cuando no se indica signo. La
+// validación real del signo la hace la API (acepta tildes, "escorpio" como
+// alias de "escorpion", etc.) — no se duplica esa lógica acá.
+const SIGNS = [
+  'aries',
+  'tauro',
+  'geminis',
+  'cancer',
+  'leo',
+  'virgo',
+  'libra',
+  'escorpion',
+  'sagitario',
+  'capricornio',
+  'acuario',
+  'piscis'
+]
+
+const buildOptions = () => ({
+  as_user: false,
+  link_names: 1,
+  icon_url: 'https://horoscopo.devschile.cl/pedrito-engel.png',
+  username: 'Pedrito Engel',
+  unfurl_links: false,
+  attachments: [{}]
+})
+
+const buildHelpMessage = () => `Debes agregar un signo zodiacal (${SIGNS.join(', ')}).`
+
+const buildErrorMessage = () => 'Ocurrió un error con la búsqueda'
+
+const buildUnknownSignMessage = signosValidos => {
+  const lista = Array.isArray(signosValidos) && signosValidos.length ? signosValidos.join(', ') : SIGNS.join(', ')
+  return `No reconozco ese signo. Usa uno de: ${lista}.`
+}
+
+// Con ?signo= la API siempre devuelve un solo signo bajo `horoscopo`. Se lee
+// la única entrada en vez de indexar por el texto que escribió la persona,
+// porque ese texto puede venir con tilde ("géminis") mientras la respuesta
+// usa siempre el slug canónico sin tilde ("geminis") como clave.
+const getSinglePrediction = data => {
+  const entries = data && data.horoscopo ? Object.entries(data.horoscopo) : []
+  if (entries.length !== 1) return null
+  const [signo, prediccion] = entries[0]
+  return { signo, prediccion }
+}
+
+const buildHoroscopeText = data => {
+  const entry = getSinglePrediction(data)
+  if (!entry) return null
+  const { nombre, amor, salud, dinero, color, numero } = entry.prediccion
+  const nota = data.vigente === false ? ' (todavía no está listo el de hoy; este es el de ayer)' : ''
+
+  return `
+Horóscopo de ${data.titulo} para ${nombre}${nota}:
+  · Amor 💖 : ${amor}
+  · Salud 🤕 : ${salud}
+  · Dinero 💰 : ${dinero}
+  · Color 🖌 : ${color}
+  · Número 🔢 : ${numero}`
+}
+
+const buildHoroscopeFields = data => {
+  const entry = getSinglePrediction(data)
+  if (!entry) return null
+  const { amor, salud, dinero, color, numero } = entry.prediccion
+
+  return [
+    { value: `💖 ${amor}`, short: false },
+    { value: `🤕 ${salud}`, short: false },
+    { value: `💰 ${dinero}`, short: false },
+    { value: `🖌 ${color}`, short: true },
+    { value: `🔢 ${numero}`, short: true }
+  ]
+}
 
 module.exports = function (robot) {
-  const signs = [
-    'aries',
-    'tauro',
-    'geminis',
-    'cancer',
-    'leo',
-    'virgo',
-    'libra',
-    'escorpion',
-    'sagitario',
-    'capricornio',
-    'acuario',
-    'piscis'
-  ]
-  const pattern = new RegExp(`hor[oó]scopo(\\s+(${signs.join('|')}))?$`, 'i')
+  const pattern = /hor[oó]scopo(\s+(\S+))?$/i
+
   robot.respond(pattern, function (res) {
     const send = options => {
       if (['SlackBot', 'Room'].includes(robot.adapter.constructor.name)) {
@@ -40,76 +105,95 @@ module.exports = function (robot) {
         res.send(options.attachments[0].fallback)
       }
     }
-    const options = {
-      as_user: false,
-      link_names: 1,
-      icon_url: 'https://pbs.twimg.com/profile_images/706872219973120000/g0U6TyxI_400x400.jpg',
-      username: 'Tía Yoli',
-      unfurl_links: false,
-      attachments: [{}]
+
+    const sendError = signoTexto => {
+      const options = buildOptions()
+      const error = buildErrorMessage()
+      options.attachments[0].fallback = error
+      options.attachments[0].title = `Horóscopo para ${signoTexto}`
+      options.attachments[0].text = error
+      options.attachments[0].color = 'danger'
+      send(options)
     }
-    const defaultError = 'Ocurrió un error con la búsqueda'
-    const signo = res.match[2] ? res.match[2].toLowerCase() : null
-    if (!signo) {
-      const help = `Debes agregar un signo zodiacal (${signs.join(', ')}).`
+
+    // Se captura cualquier palabra suelta después de "horóscopo" (con o sin
+    // tilde en la palabra "horóscopo" misma, y con o sin tilde en el
+    // signo): la validación de si es un signo real la hace la API.
+    const signoTexto = res.match[2] ? res.match[2].toLowerCase() : null
+
+    if (!signoTexto) {
+      const options = buildOptions()
+      const help = buildHelpMessage()
       options.attachments[0].fallback = help
       options.attachments[0].text = help
       options.attachments[0].color = '#004085'
       return send(options)
     }
-    robot.http(url).get()(function (err, response, body) {
-      if (err || response.statusCode !== 200) {
-        robot.emit('error', err || new Error(`Status code ${response.statusCode}`), res, 'horoscopo')
-        options.attachments[0].fallback = defaultError
-        options.attachments[0].title = `Horóscopo para ${signo}`
-        options.attachments[0].text = defaultError
-        options.attachments[0].color = 'danger'
-        return send(options)
-      }
-      try {
-        const data = JSON.parse(body)
-        const { nombre, amor, salud, dinero, color, numero } = data.horoscopo[signo]
-        const text = `
-Horóscopo de ${data.titulo} para ${nombre}:
-  · Amor 💖 : ${amor}
-  · Salud 🤕 : ${salud}
-  · Dinero 💰 : ${dinero}
-  · Color 🖌 : ${color}
-  · Número 🔢 : ${numero}`
+
+    const apiKey = process.env.HOROSCOPO_API_KEY
+    if (!apiKey) {
+      robot.emit('error', new Error('Falta la variable de entorno HOROSCOPO_API_KEY'), res, 'horoscopo')
+      return sendError(signoTexto)
+    }
+
+    robot
+      .http(`${url}?signo=${encodeURIComponent(signoTexto)}`)
+      .header('x-api-key', apiKey)
+      .timeout(5000)
+      .get()(function (err, response, body) {
+        if (err) {
+          robot.emit('error', err, res, 'horoscopo')
+          return sendError(signoTexto)
+        }
+
+        let data
+        try {
+          data = JSON.parse(body)
+        } catch (parseErr) {
+          robot.emit('error', parseErr, res, 'horoscopo')
+          return sendError(signoTexto)
+        }
+
+        if (response.statusCode === 400) {
+          const options = buildOptions()
+          const message = buildUnknownSignMessage(data && data.signos_validos)
+          options.attachments[0].fallback = message
+          options.attachments[0].text = message
+          options.attachments[0].color = '#004085'
+          return send(options)
+        }
+
+        if (response.statusCode !== 200) {
+          robot.emit('error', new Error(`Status code ${response.statusCode}`), res, 'horoscopo')
+          return sendError(signoTexto)
+        }
+
+        const text = buildHoroscopeText(data)
+        const fields = buildHoroscopeFields(data)
+        const entry = getSinglePrediction(data)
+
+        if (!text || !fields || !entry) {
+          robot.emit('error', new Error(`Respuesta sin el signo "${signoTexto}"`), res, 'horoscopo')
+          return sendError(signoTexto)
+        }
+
+        const options = buildOptions()
         options.attachments[0].fallback = text
-        options.attachments[0].title = `Horóscopo para ${signo}`
+        options.attachments[0].title = `Horóscopo para ${entry.signo}`
         options.attachments[0].color = 'good'
-        options.attachments[0].fields = [
-          {
-            value: `💖 ${amor}`,
-            short: false
-          },
-          {
-            value: `🤕 ${salud}`,
-            short: false
-          },
-          {
-            value: `💰 ${dinero}`,
-            short: false
-          },
-          {
-            value: `🖌 ${color}`,
-            short: true
-          },
-          {
-            value: `🔢 ${numero}`,
-            short: true
-          }
-        ]
+        options.attachments[0].fields = fields
         send(options)
-      } catch (err) {
-        robot.emit('error', err, res, 'horoscopo')
-        options.attachments[0].fallback = defaultError
-        options.attachments[0].title = `Horóscopo para ${signo}`
-        options.attachments[0].text = defaultError
-        options.attachments[0].color = 'danger'
-        send(options)
-      }
-    })
+      })
   })
+}
+
+module.exports._test = {
+  SIGNS,
+  buildOptions,
+  buildHelpMessage,
+  buildErrorMessage,
+  buildUnknownSignMessage,
+  buildHoroscopeText,
+  buildHoroscopeFields,
+  getSinglePrediction
 }

--- a/test/horoscopo.test.js
+++ b/test/horoscopo.test.js
@@ -1,0 +1,215 @@
+'use strict'
+
+require('coffeescript/register')
+const test = require('./helpers/ava')
+const Helper = require('hubot-test-helper')
+
+const helper = new Helper('../scripts/horoscopo.js')
+const { _test } = require('../scripts/horoscopo.js')
+const sleep = m => new Promise(resolve => setTimeout(resolve, m))
+
+const respuestaValida = {
+  titulo: 'jueves, 13 de agosto de 2026',
+  fecha: '2026-08-13',
+  zona_horaria: 'America/Santiago',
+  vigente: true,
+  horoscopo: {
+    geminis: {
+      nombre: 'Géminis',
+      amor: 'Un vínculo pendiente pide una conversación honesta.',
+      salud: 'El cuerpo pide un ritmo más lento hoy.',
+      dinero: 'Una decisión de gasto conviene postergarla un día.',
+      color: 'turquesa',
+      numero: 7,
+      elemento: 'aire',
+      rango: '21 de mayo al 20 de junio',
+      animo: 4
+    }
+  }
+}
+
+// Stub encadenable: .header().timeout().get()(cb) — misma forma que usa el
+// script contra scoped-http-client.
+const httpStub = (statusCode, body) => () => {
+  const client = {
+    header: () => client,
+    timeout: () => client,
+    get: () => cb => cb(null, { statusCode }, JSON.stringify(body))
+  }
+  return client
+}
+
+const httpErrorStub = err => () => {
+  const client = {
+    header: () => client,
+    timeout: () => client,
+    get: () => cb => cb(err, null, null)
+  }
+  return client
+}
+
+test.beforeEach(t => {
+  t.context.room = helper.createRoom({ httpd: false })
+  t.context.realApiKey = process.env.HOROSCOPO_API_KEY
+  process.env.HOROSCOPO_API_KEY = 'test-key'
+
+  // El adaptador falso de hubot-test-helper se llama "Room", que es
+  // exactamente uno de los nombres que el script usa para decidir si debe
+  // mandar por la API de attachments de Slack (`robot.adapter.client.web.
+  // chat.postMessage`). Sin este stub, cualquier `send()` revienta porque
+  // el Room de prueba no tiene `.client`. Se empuja al mismo array
+  // `messages` que usa `res.send()`, para no tener que duplicar las
+  // aserciones.
+  t.context.room.robot.adapter.client = {
+    web: {
+      chat: {
+        postMessage: (room, text, options) => {
+          t.context.room.messages.push(['hubot', options.attachments[0].fallback])
+        }
+      }
+    }
+  }
+})
+
+test.afterEach(t => {
+  process.env.HOROSCOPO_API_KEY = t.context.realApiKey
+  t.context.room.destroy()
+})
+
+test('sin signo, responde con el mensaje de ayuda', async t => {
+  t.context.room.user.say('user', 'hubot horoscopo')
+  await sleep(300)
+
+  t.deepEqual(t.context.room.messages, [
+    ['user', 'hubot horoscopo'],
+    ['hubot', _test.buildHelpMessage()]
+  ])
+})
+
+test('con signo válido, responde con el horóscopo', async t => {
+  t.context.room.robot.http = httpStub(200, respuestaValida)
+
+  t.context.room.user.say('user', 'hubot horoscopo geminis')
+  await sleep(300)
+
+  const expected = _test.buildHoroscopeText(respuestaValida)
+
+  t.deepEqual(t.context.room.messages, [
+    ['user', 'hubot horoscopo geminis'],
+    ['hubot', expected]
+  ])
+})
+
+test('acepta el signo escrito con tilde y con "horóscopo" con tilde', async t => {
+  t.context.room.robot.http = httpStub(200, respuestaValida)
+
+  t.context.room.user.say('user', 'hubot horóscopo géminis')
+  await sleep(300)
+
+  t.deepEqual(t.context.room.messages, [
+    ['user', 'hubot horóscopo géminis'],
+    ['hubot', _test.buildHoroscopeText(respuestaValida)]
+  ])
+})
+
+test('avisa cuando el horóscopo de hoy no está listo y muestra el de ayer', async t => {
+  const respuestaVieja = { ...respuestaValida, vigente: false }
+  t.context.room.robot.http = httpStub(200, respuestaVieja)
+
+  t.context.room.user.say('user', 'hubot horoscopo geminis')
+  await sleep(300)
+
+  const mensaje = t.context.room.messages[1][1]
+  t.true(mensaje.includes('todavía no está listo el de hoy'))
+})
+
+test('signo desconocido (400), responde con la lista de signos válidos', async t => {
+  t.context.room.robot.http = httpStub(400, {
+    error: 'Signo desconocido',
+    signos_validos: ['aries', 'tauro']
+  })
+
+  t.context.room.user.say('user', 'hubot horoscopo ofiuco')
+  await sleep(300)
+
+  t.deepEqual(t.context.room.messages, [
+    ['user', 'hubot horoscopo ofiuco'],
+    ['hubot', _test.buildUnknownSignMessage(['aries', 'tauro'])]
+  ])
+})
+
+test('error de red, responde con el mensaje de error genérico', async t => {
+  t.context.room.robot.http = httpErrorStub(new Error('boom'))
+
+  t.context.room.user.say('user', 'hubot horoscopo geminis')
+  await sleep(300)
+
+  t.deepEqual(t.context.room.messages, [
+    ['user', 'hubot horoscopo geminis'],
+    ['hubot', _test.buildErrorMessage()]
+  ])
+})
+
+test('respuesta 500, responde con el mensaje de error genérico', async t => {
+  t.context.room.robot.http = httpStub(500, { error: 'falla interna' })
+
+  t.context.room.user.say('user', 'hubot horoscopo geminis')
+  await sleep(300)
+
+  t.deepEqual(t.context.room.messages, [
+    ['user', 'hubot horoscopo geminis'],
+    ['hubot', _test.buildErrorMessage()]
+  ])
+})
+
+test('body no-JSON, responde con el mensaje de error genérico en vez de reventar', async t => {
+  t.context.room.robot.http = () => {
+    const client = {
+      header: () => client,
+      timeout: () => client,
+      get: () => cb => cb(null, { statusCode: 200 }, 'esto no es json')
+    }
+    return client
+  }
+
+  t.context.room.user.say('user', 'hubot horoscopo geminis')
+  await sleep(300)
+
+  t.deepEqual(t.context.room.messages, [
+    ['user', 'hubot horoscopo geminis'],
+    ['hubot', _test.buildErrorMessage()]
+  ])
+})
+
+// Serial: muta process.env.HOROSCOPO_API_KEY, que es estado global
+// compartido con el resto de los tests de este archivo (AVA los corre en
+// paralelo por defecto). En paralelo, el beforeEach de otro test puede
+// volver a poner la key justo cuando este test la borra.
+test.serial('sin HOROSCOPO_API_KEY configurada, responde con error sin llamar a la API', async t => {
+  delete process.env.HOROSCOPO_API_KEY
+  let seLlamoLaApi = false
+  t.context.room.robot.http = () => {
+    seLlamoLaApi = true
+    return httpStub(200, respuestaValida)()
+  }
+
+  t.context.room.user.say('user', 'hubot horoscopo geminis')
+  await sleep(300)
+
+  t.false(seLlamoLaApi)
+  t.deepEqual(t.context.room.messages, [
+    ['user', 'hubot horoscopo geminis'],
+    ['hubot', _test.buildErrorMessage()]
+  ])
+})
+
+test('getSinglePrediction devuelve null si la respuesta no trae horoscopo', t => {
+  t.is(_test.getSinglePrediction({}), null)
+  t.is(_test.getSinglePrediction({ horoscopo: {} }), null)
+})
+
+test('getSinglePrediction devuelve el signo y la predicción de la única entrada', t => {
+  const entry = _test.getSinglePrediction(respuestaValida)
+  t.is(entry.signo, 'geminis')
+  t.is(entry.prediccion.nombre, 'Géminis')
+})


### PR DESCRIPTION
## Descripción

La API anterior (api.xor.cl/tyaas) está caída (responde 200 con body vacío), así que el comando fallaba siempre. Se reemplaza por la nueva API de devsChile, que requiere API key (HOROSCOPO_API_KEY) y acepta signos con tilde delegando esa validación a la API en vez de duplicarla acá. Se agrega timeout de 5s (antes no había ninguno) y se cubre el script con tests por primera vez.

De paso, cambia la persona de "Tía Yoli" a "Pedrito Engel".

## Ejemplo de comportamiento

```
> huemul horoscopo acuario
```
<img width="530" height="448" alt="Screenshot 2026-08-13 at 23 51 58" src="https://github.com/user-attachments/assets/cd12ee79-8e71-4e43-9093-fed86e434658" />
