### PR TITLE
feat(horoscopo): agregar variante dev via flag --dev

### DIFF
--- a/scripts/horoscopo.js
+++ b/scripts/horoscopo.js
@@ -3,6 +3,7 @@
 //
 // Dependencies:
 //   https://horoscopo.devschile.cl/api/horoscopo
+//   https://horoscopo.devschile.cl/api/horoscopo-dev
 //
 // Configuration:
 //   HOROSCOPO_API_KEY - API key requerida por horoscopo.devschile.cl (ver README del proyecto)
@@ -10,13 +11,16 @@
 // Commands:
 //   hubot horóscopo <signo zodiacal> - Muestra el horóscopo del día para el signo indicado. Ejemplo: `hubot horóscopo leo`
 //   hubot horoscopo <signo zodiacal> - Muestra el horóscopo del día para el signo indicado. Ejemplo: `hubot horoscopo leo`
+//   hubot horoscopo <signo zodiacal> --dev - Como el anterior, pero con la vida de quien programa. Ejemplo: `hubot horoscopo leo --dev`
 //
 // Author:
 //   @jorgeepunan
 
 'use strict'
 
-const url = 'https://horoscopo.devschile.cl/api/horoscopo'
+const CLASSIC_URL = 'https://horoscopo.devschile.cl/api/horoscopo'
+const DEV_URL = 'https://horoscopo.devschile.cl/api/horoscopo-dev'
+const DEV_FLAG = '--dev'
 
 // Lista solo para el mensaje de ayuda cuando no se indica signo. La
 // validación real del signo la hace la API (acepta tildes, "escorpio" como
@@ -45,13 +49,26 @@ const buildOptions = () => ({
   attachments: [{}]
 })
 
-const buildHelpMessage = () => `Debes agregar un signo zodiacal (${SIGNS.join(', ')}).`
+const buildHelpMessage = () =>
+  `Debes agregar un signo zodiacal (${SIGNS.join(', ')}). Agrega "${DEV_FLAG}" al final para la variante para developers.`
 
 const buildErrorMessage = () => 'Ocurrió un error con la búsqueda'
 
 const buildUnknownSignMessage = signosValidos => {
   const lista = Array.isArray(signosValidos) && signosValidos.length ? signosValidos.join(', ') : SIGNS.join(', ')
   return `No reconozco ese signo. Usa uno de: ${lista}.`
+}
+
+// Todo lo que sigue a "horóscopo" llega como un solo bloque de texto (ver el
+// patrón en `module.exports`), porque el orden entre el signo y "--dev" no
+// está fijo ("horoscopo leo --dev" y "horoscopo --dev leo" deben funcionar
+// igual). Se separa en tokens y se distingue la bandera del signo por su
+// valor literal, no por posición.
+const parseArgs = rawArgs => {
+  const tokens = rawArgs ? rawArgs.trim().split(/\s+/).filter(Boolean) : []
+  const isDev = tokens.some(token => token.toLowerCase() === DEV_FLAG)
+  const signoToken = tokens.find(token => token.toLowerCase() !== DEV_FLAG)
+  return { signoTexto: signoToken ? signoToken.toLowerCase() : null, isDev }
 }
 
 // Con ?signo= la API siempre devuelve un solo signo bajo `horoscopo`. Se lee
@@ -95,7 +112,7 @@ const buildHoroscopeFields = data => {
 }
 
 module.exports = function (robot) {
-  const pattern = /hor[oó]scopo(\s+(\S+))?$/i
+  const pattern = /hor[oó]scopo(\s+(.+))?$/i
 
   robot.respond(pattern, function (res) {
     const send = options => {
@@ -116,10 +133,8 @@ module.exports = function (robot) {
       send(options)
     }
 
-    // Se captura cualquier palabra suelta después de "horóscopo" (con o sin
-    // tilde en la palabra "horóscopo" misma, y con o sin tilde en el
-    // signo): la validación de si es un signo real la hace la API.
-    const signoTexto = res.match[2] ? res.match[2].toLowerCase() : null
+    const { signoTexto, isDev } = parseArgs(res.match[2])
+    const url = isDev ? DEV_URL : CLASSIC_URL
 
     if (!signoTexto) {
       const options = buildOptions()
@@ -189,6 +204,7 @@ module.exports = function (robot) {
 
 module.exports._test = {
   SIGNS,
+  parseArgs,
   buildOptions,
   buildHelpMessage,
   buildErrorMessage,

--- a/test/horoscopo.test.js
+++ b/test/horoscopo.test.js
@@ -29,14 +29,21 @@ const respuestaValida = {
 }
 
 // Stub encadenable: .header().timeout().get()(cb) — misma forma que usa el
-// script contra scoped-http-client.
-const httpStub = (statusCode, body) => () => {
-  const client = {
-    header: () => client,
-    timeout: () => client,
-    get: () => cb => cb(null, { statusCode }, JSON.stringify(body))
+// script contra scoped-http-client. Expone la URL pedida en `.calls` para
+// poder verificar a qué endpoint apuntó cada comando.
+const httpStub = (statusCode, body) => {
+  const calls = []
+  const factory = url => {
+    calls.push(url)
+    const client = {
+      header: () => client,
+      timeout: () => client,
+      get: () => cb => cb(null, { statusCode }, JSON.stringify(body))
+    }
+    return client
   }
-  return client
+  factory.calls = calls
+  return factory
 }
 
 const httpErrorStub = err => () => {
@@ -98,6 +105,69 @@ test('con signo válido, responde con el horóscopo', async t => {
     ['user', 'hubot horoscopo geminis'],
     ['hubot', expected]
   ])
+})
+
+test('horoscopo <signo> --dev responde con el horóscopo y pega contra el endpoint dev', async t => {
+  const stub = httpStub(200, respuestaValida)
+  t.context.room.robot.http = stub
+
+  t.context.room.user.say('user', 'hubot horoscopo geminis --dev')
+  await sleep(300)
+
+  const expected = _test.buildHoroscopeText(respuestaValida)
+
+  t.deepEqual(t.context.room.messages, [
+    ['user', 'hubot horoscopo geminis --dev'],
+    ['hubot', expected]
+  ])
+  t.is(stub.calls.length, 1)
+  t.true(stub.calls[0].startsWith('https://horoscopo.devschile.cl/api/horoscopo-dev?'))
+})
+
+test('horoscopo --dev <signo> (orden invertido) también pega contra el endpoint dev', async t => {
+  const stub = httpStub(200, respuestaValida)
+  t.context.room.robot.http = stub
+
+  t.context.room.user.say('user', 'hubot horoscopo --dev geminis')
+  await sleep(300)
+
+  t.is(stub.calls.length, 1)
+  t.true(stub.calls[0].startsWith('https://horoscopo.devschile.cl/api/horoscopo-dev?'))
+})
+
+test('horoscopo (sin --dev) pega contra el endpoint clásico, no el dev', async t => {
+  const stub = httpStub(200, respuestaValida)
+  t.context.room.robot.http = stub
+
+  t.context.room.user.say('user', 'hubot horoscopo geminis')
+  await sleep(300)
+
+  t.is(stub.calls.length, 1)
+  t.true(stub.calls[0].startsWith('https://horoscopo.devschile.cl/api/horoscopo?'))
+  t.false(stub.calls[0].includes('horoscopo-dev'))
+})
+
+test('horoscopo --dev (sin signo) responde con el mensaje de ayuda, sin llamar a la API', async t => {
+  const stub = httpStub(200, respuestaValida)
+  t.context.room.robot.http = stub
+
+  t.context.room.user.say('user', 'hubot horoscopo --dev')
+  await sleep(300)
+
+  t.is(stub.calls.length, 0)
+  t.deepEqual(t.context.room.messages, [
+    ['user', 'hubot horoscopo --dev'],
+    ['hubot', _test.buildHelpMessage()]
+  ])
+})
+
+test('parseArgs distingue el signo de la bandera --dev, en cualquier orden', t => {
+  t.deepEqual(_test.parseArgs('leo --dev'), { signoTexto: 'leo', isDev: true })
+  t.deepEqual(_test.parseArgs('--dev leo'), { signoTexto: 'leo', isDev: true })
+  t.deepEqual(_test.parseArgs('leo'), { signoTexto: 'leo', isDev: false })
+  t.deepEqual(_test.parseArgs('--dev'), { signoTexto: null, isDev: true })
+  t.deepEqual(_test.parseArgs(null), { signoTexto: null, isDev: false })
+  t.deepEqual(_test.parseArgs('LEO --DEV'), { signoTexto: 'leo', isDev: true })
 })
 
 test('acepta el signo escrito con tilde y con "horóscopo" con tilde', async t => {


### PR DESCRIPTION
## Descripción

La API de horoscopo.devschile.cl ahora expone `/api/horoscopo-dev` (mismo contrato que /api/horoscopo, pero con la vida de quien programa en vez de un horóscopo genérico). Se agrega el flag --dev al comando existente en vez de un comando separado, para no duplicar el nombre:

 `huemul horoscopo <signo>`          -> variante clásica (default)
 `huemul horoscopo <signo> --dev`    -> variante dev
 `huemul horoscopo --dev <signo>`    -> mismo resultado, orden invertido

parseArgs() distingue el signo de la bandera por su valor literal, no por posición, así que ambos órdenes funcionan igual. Toda la lógica de lectura/formato se comparte entre ambas variantes; lo único que cambia es la URL a la que apunta cada llamada.