### PR TITLE
chore(tusecreto): migrar script al API de Slack actualizada

### DIFF
--- a/scripts/tusecreto.js
+++ b/scripts/tusecreto.js
@@ -1,13 +1,13 @@
 // Description:
 //   Tu secreto queda entre tú y :huemul:
-//   Dile un secreto a @huemul por DM y éste lo anunciará en el canal seleccionado o #random sin mencionarte.
+//   Dile un secreto a @huemul por DM y este lo anunciará en el canal seleccionado o #random sin mencionarte.
 //
 // Dependencies:
 //   None
 //
 // Configuration:
 //   HUBOT_MYSECRET_ALLOWED_CHANNELS: Lista de canales separados por comas.
-//                                    Ej: '#random,#pegas,#otrocanal'
+//                                    Ej: '#random,#trabajos,#otrocanal'
 //
 // Commands:
 //   hubot mi secreto <secreto> - Envia el secreto al canal #random.
@@ -16,12 +16,15 @@
 // Author:
 //   @jorgeepunan
 
-module.exports = function (robot) {
-  return robot.respond(/mi secreto (.*)/i, function (msg) {
-    var secreto = msg.match[1]
-    var channel = '#random'
-    var allowedChannels = process.env.HUBOT_MYSECRET_ALLOWED_CHANNELS || '#random'
-    var secretoArr = secreto.split(' ')
+const { getClient } = require('./helpers/client')
+
+module.exports = robot => {
+  const web = getClient()
+  robot.respond(/mi secreto (.*)/i, msg => {
+    let secreto = msg.match[1]
+    let channel = '#random'
+    let allowedChannels = process.env.HUBOT_MYSECRET_ALLOWED_CHANNELS || '#random'
+    const secretoArr = secreto.split(' ')
 
     allowedChannels = allowedChannels.split(',')
 
@@ -34,24 +37,26 @@ module.exports = function (robot) {
       return robot.messageRoom(msg.message.user.id, '¿Y el secreto?')
     }
 
-    var slackChannel = robot.adapter.client.rtm.dataStore.getChannelByName(channel)
+    const forbiddenWords = ['@here', '@channel', '@group', '@everyone']
 
-    if (!slackChannel) {
-      return robot.messageRoom(msg.message.user.id, 'No sé qué canal es ese.')
-    }
-
-    if (!slackChannel.is_member) {
-      return robot.messageRoom(msg.message.user.id, 'No estoy en ' + channel + '. :sadhuemul:')
-    }
-
-    var forbiddenWords = ['@here', '@channel', '@group', '@everyone']
-
-    for (var i = 0; i < forbiddenWords.length; i++) {
+    for (let i = 0; i < forbiddenWords.length; i++) {
       if (secreto.indexOf(forbiddenWords[i]) !== -1) {
-        return robot.messageRoom(slackChannel.id, 'El tonto de ' + msg.message.user.name + ' trató de usar @')
+        return robot.messageRoom(msg.message.user.id, 'El tonto de ' + msg.message.user.name + ' trató de usar @')
       }
     }
 
-    return robot.messageRoom(slackChannel.id, ':speak_no_evil: *Un secreto:* ' + secreto)
+    web.conversations.list({ types: 'public_channel,private_channel' }).then(res => {
+      const slackChannel = res.channels.find(c => c.name === channel.replace(/^#/, ''))
+
+      if (!slackChannel) {
+        return robot.messageRoom(msg.message.user.id, 'No sé qué canal es ese.')
+      }
+
+      if (!slackChannel.is_member) {
+        return robot.messageRoom(msg.message.user.id, 'No estoy en ' + channel + '. :sadhuemul:')
+      }
+
+      return robot.messageRoom(slackChannel.id, ':speak_no_evil: *Un secreto:* ' + secreto)
+    })
   })
 }

--- a/test/tusecreto.test.js
+++ b/test/tusecreto.test.js
@@ -1,0 +1,112 @@
+'use strict'
+
+require('coffeescript/register')
+const test = require('./helpers/ava')
+const Helper = require('hubot-test-helper')
+const nock = require('nock')
+
+const helper = new Helper('../scripts/tusecreto.js')
+
+const randomChannel = { id: 'C123', name: 'random', is_member: true }
+
+const mockConversations = channels => {
+  nock.cleanAll()
+  nock('https://slack.com')
+    .post('/api/conversations.list')
+    .reply(200, { ok: true, channels })
+}
+
+test.beforeEach(t => {
+  delete process.env.HUBOT_MYSECRET_ALLOWED_CHANNELS
+  t.context.room = helper.createRoom({ httpd: false })
+  t.context.room.robot.golden = { isGold: () => false }
+  nock('https://slack.com')
+    .post('/api/conversations.list')
+    .optionally()
+    .reply(200, { ok: true, channels: [randomChannel] })
+})
+
+test.afterEach(t => {
+  delete process.env.HUBOT_MYSECRET_ALLOWED_CHANNELS
+  t.context.room.destroy()
+  nock.cleanAll()
+})
+
+test.cb.serial('mi secreto - publica en #random por defecto', t => {
+  t.context.room.user.say('user', 'hubot mi secreto este es mi secreto')
+  setTimeout(() => {
+    t.deepEqual(t.context.room.messages, [['user', 'hubot mi secreto este es mi secreto']])
+    t.deepEqual(t.context.room.robot.messagesTo.C123, [
+      ['hubot', ':speak_no_evil: *Un secreto:* este es mi secreto']
+    ])
+    t.end()
+  }, 500)
+})
+
+test.cb.serial('mi secreto - publica en canal permitido explícito', t => {
+  process.env.HUBOT_MYSECRET_ALLOWED_CHANNELS = '#random,#pegas'
+  mockConversations([{ id: 'C2', name: 'pegas', is_member: true }])
+  t.context.room.user.say('user', 'hubot mi secreto pegas contenido secreto')
+  setTimeout(() => {
+    t.deepEqual(t.context.room.robot.messagesTo.C2, [
+      ['hubot', ':speak_no_evil: *Un secreto:* contenido secreto']
+    ])
+    t.end()
+  }, 500)
+})
+
+test.cb.serial('mi secreto - gold puede usar un canal fuera del allowlist', t => {
+  t.context.room.robot.golden = { isGold: () => true }
+  mockConversations([{ id: 'C2', name: 'pegas', is_member: true }])
+  t.context.room.user.say('user', 'hubot mi secreto pegas contenido secreto')
+  setTimeout(() => {
+    t.deepEqual(t.context.room.robot.messagesTo.C2, [
+      ['hubot', ':speak_no_evil: *Un secreto:* contenido secreto']
+    ])
+    t.end()
+  }, 500)
+})
+
+test.cb.serial('mi secreto - canal desconocido', t => {
+  process.env.HUBOT_MYSECRET_ALLOWED_CHANNELS = '#random,#nope'
+  mockConversations([randomChannel])
+  t.context.room.user.say('user', 'hubot mi secreto nope contenido')
+  setTimeout(() => {
+    t.deepEqual(t.context.room.robot.messagesTo.user, [
+      ['hubot', 'No sé qué canal es ese.']
+    ])
+    t.end()
+  }, 500)
+})
+
+test.cb.serial('mi secreto - huemul no es miembro del canal', t => {
+  process.env.HUBOT_MYSECRET_ALLOWED_CHANNELS = '#random,#notmember'
+  mockConversations([{ id: 'C3', name: 'notmember', is_member: false }])
+  t.context.room.user.say('user', 'hubot mi secreto notmember contenido')
+  setTimeout(() => {
+    t.deepEqual(t.context.room.robot.messagesTo.user, [
+      ['hubot', 'No estoy en #notmember. :sadhuemul:']
+    ])
+    t.end()
+  }, 500)
+})
+
+test.cb.serial('mi secreto - sin contenido', t => {
+  t.context.room.user.say('user', 'hubot mi secreto random')
+  setTimeout(() => {
+    t.deepEqual(t.context.room.robot.messagesTo.user, [
+      ['hubot', '¿Y el secreto?']
+    ])
+    t.end()
+  }, 500)
+})
+
+test.cb.serial('mi secreto - bloquea mención a todos', t => {
+  t.context.room.user.say('user', 'hubot mi secreto random @here contenido')
+  setTimeout(() => {
+    t.deepEqual(t.context.room.robot.messagesTo.user, [
+      ['hubot', 'El tonto de user trató de usar @']
+    ])
+    t.end()
+  }, 500)
+})


### PR DESCRIPTION
## Qué y por qué

`scripts/tusecreto.js` dejó de funcionar porque dependía del **RTM API legado de Slack** (`robot.adapter.client.rtm.dataStore.getChannelByName`), que Slack deprecó y ya no entrega el estado de canales. Como resultado, `getChannelByName` devolvía `undefined` y el bot respondía "No sé qué canal es ese." sin publicar el secreto.

## Cambios

- `scripts/tusecreto.js`: se reemplaza el lookup por el **Web API** vía `web.conversations.list({ types: 'public_channel,private_channel' })`, usando el helper existente `scripts/helpers/client.js` (mismo patrón que `cumpleaños.js`, `gpt.js`, `karma.js`).
  - Se conserva la validación de membresía (`is_member`) y los mensajes de error por DM.
  - El aviso por palabra prohibida (@here/@channel/@everyone) ahora se envía por DM al usuario en vez de publicarse en el canal.
- `test/tusecreto.test.js` (nuevo): 7 tests con `hubot-test-helper` + `nock` (sin necesidad de Slack) cubriendo publicación en #random, canal permitido explícito, usuario gold, canal desconocido, sin membresía, sin contenido y menciones bloqueadas.

## Verificación

- `npx eslint scripts/tusecreto.js test/tusecreto.test.js` limpio.
- `yarn test`: 131 tests pasan.