### PR TITLE
fix(gold): preserve valid projection on malformed sync

### DIFF
--- a/scripts/gold.js
+++ b/scripts/gold.js
@@ -143,11 +143,9 @@ module.exports = robot => {
     const members = []
     for (const member of payload.members) {
       const paidThrough = member && (member.paidThrough || member.paid_through)
-      if (member && typeof member.handle === 'string' && paidThrough) {
-        const slackId = member.slackId || member.slack_id
-        if (typeof slackId !== 'string' || !slackId) continue
-        members.push({ slackId, handle: member.handle, paidThrough })
-      }
+      const slackId = member && (member.slackId || member.slack_id)
+      if (!member || typeof member.handle !== 'string' || !paidThrough || typeof slackId !== 'string' || !slackId) return null
+      members.push({ slackId, handle: member.handle, paidThrough })
     }
     return {
       version: typeof payload.version === 'number' ? payload.version : 0,
@@ -262,7 +260,8 @@ module.exports = robot => {
       if (!identity || !['hubot', 'slack'].includes(identity.handleSource) || !slackId || !handle) continue
       next[slackId] = { handle, resolvedAt }
       if (identity.handleSource === 'slack' && typeof robot.brain.userForId === 'function') {
-        robot.brain.userForId(slackId).name = handle
+        const user = robot.brain.userForId(slackId)
+        if (user) user.name = handle
       }
       changed = true
     }

--- a/test/gold.test.js
+++ b/test/gold.test.js
@@ -768,6 +768,40 @@ test.serial('gold status no confía en el label literal para consultar otra iden
   t.false(hubotMessages(room).some(text => text.includes('victima es gold')))
 })
 
+test.serial('gold status no falla si el brain no puede materializar el usuario', async t => {
+  blockAutoRefresh()
+  const room = createRoom(t)
+  room.robot.auth = { isAdmin: () => true, hasRole: () => false }
+  room.robot.brain.set('gold_projection', projectionOf([
+    { slackId: 'UALICE', handle: 'alice', paidThrough: '2027-03-15T12:00:00.000Z' }
+  ]))
+  mockUserInfo('UALICE', 'alice-actual')
+  room.robot.brain.userForId = () => null
+
+  room.user.say('user', 'hubot gold status <@UALICE>')
+  await waitUntil(() => hubotMessages(room).some(text => text.includes('alice-actual es gold')))
+
+  t.true(hubotMessages(room).some(text => text.includes('alice-actual es gold')))
+})
+
+test.serial('gold sync rechaza una proyección parcial y conserva la última válida', async t => {
+  mockProjection([{ slackId: 'UALICE', handle: 'alice', paidThrough: '2027-03-15T12:00:00.000Z' }])
+  const room = createRoom(t, { httpd: true })
+  await waitUntil(() => room.robot.server && room.robot.server.listening)
+  await waitUntil(() => room.robot.golden.isGold({ id: 'UALICE', name: 'alice' }))
+  const port = room.robot.server.address().port
+
+  mockProjection([{ handle: 'alice', paidThrough: '2027-03-15T12:00:00.000Z' }])
+  const response = await fetch(`http://127.0.0.1:${port}/gold/sync`, {
+    method: 'POST',
+    headers: { authorization: 'Bearer sync-secret' }
+  })
+
+  t.is(response.status, 502)
+  t.true(room.robot.golden.isGold({ id: 'UALICE', name: 'alice' }))
+  t.is(room.robot.brain.get('gold_projection').members[0].slackId, 'UALICE')
+})
+
 test.serial('/gold/webhook legado responde 410', async t => {
   absorbAutoRefresh()
   const room = createRoom(t, { httpd: true })


### PR DESCRIPTION
## Context
Follow-up to #771 after independent review.

## Fixes
- Tolerate `brain.userForId()` returning null while refreshing the display-handle cache.
- Reject any incomplete projection entry instead of replacing the last valid projection and revoking local authorization.

## Verification
- Added regression tests for both cases.
- 161 tests pass with Node 24, Yarn lock and `TZ=America/Santiago`.
- ESLint, syntax checks and `git diff --check` pass.
