### PR TITLE
chore(apoyar): add cómo donar fallback message

### DIFF
--- a/scripts/como-apoyar.js
+++ b/scripts/como-apoyar.js
@@ -10,6 +10,8 @@
 // Commands:
 //   hubot como apoyar - Muestra las instrucciones de cómo apoyar
 //   hubot cómo apoyar - Muestra las instrucciones de cómo apoyar
+//   hubot como donar - Explica que ya no se reciben donaciones, solo suscripciones
+//   hubot cómo donar - Explica que ya no se reciben donaciones, solo suscripciones
 //
 // Authors:
 //   @jorgeepunan @hectorpalmatellez
@@ -30,7 +32,34 @@ const PAYMENT_METHODS = new Map([
   ]
 ])
 
+const DONATION_TEXT =
+  'Por motivos legales y tributarios ya no recibimos donaciones: el apoyo a la comunidad se realiza exclusivamente mediante suscripción. Escribe `huemul cómo apoyar` para conocer las opciones disponibles.'
+const DONATION_FOOTER =
+  'Gracias :pray: por el interés en aportar :gold: a que siga creciendo la comunidad devsChile.'
+
 module.exports = robot => {
+  robot.respond(/c(o|ó)mo donar/i, msg => {
+    if (['SlackBot', 'Room'].includes(robot.adapter.constructor.name)) {
+      const options = {
+        as_user: true,
+        link_names: 1,
+        unfurl_links: false,
+        attachments: [
+          {
+            fallback: DONATION_TEXT,
+            text: DONATION_TEXT,
+            title: 'Cómo donar',
+            title_link: 'https://devschile.cl/',
+            footer: DONATION_FOOTER
+          }
+        ]
+      }
+      robot.adapter.client.web.chat.postMessage(msg.message.room, null, options)
+    } else {
+      msg.send(DONATION_TEXT)
+    }
+  })
+
   robot.respond(/c(o|ó)mo apoyar/i, msg => {
     const text =
       `Para mantener el servidor donde se aloja el :robot_face: :huemul: y otros proyectos que creamos desde y para la comunidad, se reciben aportes desde ${SUPPORT_AMOUNT} por diferentes medios`

--- a/test/como-apoyar.test.js
+++ b/test/como-apoyar.test.js
@@ -1,0 +1,73 @@
+'use strict'
+
+require('coffeescript/register')
+const test = require('./helpers/ava')
+const Helper = require('hubot-test-helper')
+
+const helper = new Helper('../scripts/como-apoyar.js')
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+// El adaptador falso de hubot-test-helper se llama "Room", uno de los nombres
+// que el script usa para decidir si responde con attachments de Slack
+// (`robot.adapter.client.web.chat.postMessage`). Sin este stub, el handler
+// revienta porque el Room de prueba no tiene `.client`.
+test.beforeEach(t => {
+  t.context.room = helper.createRoom({ httpd: false })
+  t.context.room.robot.adapter.client = {
+    web: {
+      chat: {
+        postMessage: (channel, text, options) => {
+          t.context.postMessage = { channel, text, options }
+        }
+      }
+    }
+  }
+})
+test.afterEach(t => {
+  t.context.room.destroy()
+})
+
+const attachment = t => t.context.postMessage.options.attachments[0]
+
+test('cómo donar responde con el aviso de suscripción obligatoria', async t => {
+  t.context.room.user.say('user', 'hubot cómo donar')
+  await sleep(300)
+  const att = attachment(t)
+  t.deepEqual(att.title, 'Cómo donar')
+  t.true(att.text.includes('ya no recibimos donaciones'))
+  t.true(att.text.includes('suscripción'))
+  t.true(att.text.includes('cómo apoyar'))
+  t.deepEqual(att.footer, 'Gracias :pray: por el interés en aportar :gold: a que siga creciendo la comunidad devsChile.')
+})
+
+test('como donar sin tilde responde igual', async t => {
+  t.context.room.user.say('user', 'hubot como donar')
+  await sleep(300)
+  t.deepEqual(attachment(t).title, 'Cómo donar')
+})
+
+test('cómo donar no gatilla la respuesta de apoyar', async t => {
+  t.context.room.user.say('user', 'hubot cómo donar')
+  await sleep(300)
+  t.false(attachment(t).text.includes('Para mantener el servidor'))
+  t.deepEqual(attachment(t).fields, undefined)
+})
+
+test('cómo apoyar sigue mostrando las vías de suscripción', async t => {
+  t.context.room.user.say('user', 'hubot cómo apoyar')
+  await sleep(300)
+  const att = attachment(t)
+  t.deepEqual(att.title, 'Cómo apoyar')
+  const titles = att.fields.map(field => field.title)
+  t.deepEqual(titles, ['devsChile gold', 'Suscripción mensual', 'Transferencia'])
+  t.true(att.text.includes(process.env.SUBSCRIPTION_AMOUNT || '$4.000'))
+})
+
+test('cómo apoyar no menciona donaciones', async t => {
+  t.context.room.user.say('user', 'hubot cómo apoyar')
+  await sleep(300)
+  const { text, fields, footer } = attachment(t)
+  const blob = [text, footer, ...fields.map(field => `${field.title} ${field.value}`)].join(' ')
+  t.false(/donativ|donaci/i.test(blob))
+})


### PR DESCRIPTION
## Descripción
<!--- Proporcione un resumen general de que hace el nuevo script -->
Agrega un handler para `hubot cómo donar` en `scripts/como-apoyar.js` que responde con un mensaje explicando que, por motivos legales y tributarios, ya no se reciben donaciones y que el apoyo a la comunidad es exclusivamente mediante suscripción, sugiriendo usar `hubot cómo apoyar`. Incluye tests de cobertura para el nuevo comando y el flujo existente de apoyo.

## Ejemplo de comportamiento
<!---
Proporcione un snippet indicando un ejemplo del comportamiento.
Ejemplo:
```
> hubot my-script
> <salida esperada>
```

Adicionalmente puedes agregar screenshots de como se vera si estas usando attachments.
Para ello puedes usar https://api.slack.com/docs/messages/builder para tener una previsualización.
-->
```
> hubot cómo donar
> [attachment] Cómo donar
> Por motivos legales y tributarios ya no recibimos donaciones: el apoyo a la comunidad se realiza exclusivamente mediante suscripción. Escribe `hubot cómo apoyar` para conocer las opciones disponibles.
```