### PR TITLE
feat(supermuseum): busca+recomienda juegos desde SuperMuseum

### DIFF
--- a/scripts/supermuseum.js
+++ b/scripts/supermuseum.js
@@ -1,0 +1,117 @@
+// Description:
+//   Busca y recomienda juegos del SuperMuseum (supermuseum.netlify.app).
+//
+// Dependencies:
+//   None
+//
+// Configuration:
+//   None
+//
+// Commands:
+//   hubot supermuseum - Retorna un juego al azar de todas las bibliotecas
+//   hubot supermuseum <plataforma> - Retorna un juego al azar de esa plataforma (ej: snes, arcade, dos)
+//   hubot supermuseum <texto> - Lista hasta 10 juegos cuyo título contenga el texto
+//
+// Author:
+//   @livercake
+
+const BASE_URL = 'https://supermuseum.netlify.app'
+const MAX_RESULTS = 10
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000 // 24h: supermuseum publica nuevo contenido una vez al día
+
+// Fuente de verdad en supermuseum-v2: PLATFORM_ORDER en src/constants/ui.js
+const PLATFORMS = ['nes', 'gb', 'pce', 'snes', 'genesis', 'n64', 'saturn', 'psx', 'psp', 'gba', 'arcade', 'dos', 'pico8']
+
+const PLATFORM_LABELS = {
+  nes: 'Nintendo',
+  snes: 'Super Nintendo',
+  genesis: 'Genesis/32X',
+  n64: 'Nintendo 64',
+  gb: 'Game Boy',
+  gba: 'GameBoy Advance',
+  dos: 'MS-DOS',
+  arcade: 'Arcade',
+  pico8: 'PICO-8',
+  pce: 'HuCards',
+  saturn: 'Saturn',
+  psx: 'PlayStation',
+  psp: 'PlayStation Portable'
+}
+
+// El museo solo acepta browsers y bots conocidos (block-non-browser en
+// Netlify: 403 sin Sec-Fetch-* ni UA reconocido). 'hubot' está allowlisteado
+// en el museo (src/utils/browser-check.js), así que nos identificamos
+// honestamente en vez de spoofear un browser.
+const HUBOT_UA = 'huemul-hubot (devsChile Slack bot)'
+
+let cache = { games: null, fetchedAt: 0 }
+
+function fetchLibraries (robot, cb) {
+  if (cache.games && Date.now() - cache.fetchedAt < CACHE_TTL_MS) {
+    return cb(null, cache.games)
+  }
+  const games = []
+  let pending = PLATFORMS.length
+  let settled = false
+  PLATFORMS.forEach(platform => {
+    robot.http(`${BASE_URL}/json/${platform}.json`).header('User-Agent', HUBOT_UA).get()((err, res, body) => {
+      if (settled) return
+      if (err || !res || res.statusCode !== 200 || !body) {
+        settled = true
+        return cb(err || new Error(`HTTP ${res && res.statusCode} fetching ${platform}.json`))
+      }
+      let lib
+      try {
+        lib = JSON.parse(body)
+      } catch (parseErr) {
+        settled = true
+        return cb(parseErr)
+      }
+      lib.forEach(game => games.push(game))
+      pending -= 1
+      if (pending === 0) {
+        settled = true
+        cache = { games, fetchedAt: Date.now() }
+        cb(null, games)
+      }
+    })
+  })
+}
+
+function formatGame (game) {
+  const label = PLATFORM_LABELS[game.platform] || game.platform
+  const line = `${game.title} (${game.year}) - ${game.developer} - ${label}`
+  return `${line}\n${BASE_URL}/?play=${game.platform}:${game.serial}`
+}
+
+module.exports = function (robot) {
+  robot.respond(/supermuseum\s?(.*)/i, function (msg) {
+    const query = (msg.match[1] || '').trim()
+    fetchLibraries(robot, function (err, games) {
+      if (err || !games) {
+        if (err) robot.emit('error', err, msg, 'supermuseum')
+        return msg.reply('ocurrió un error buscando en el SuperMuseum, intenta de nuevo más tarde')
+      }
+      if (!query) {
+        return msg.send(formatGame(msg.random(games)))
+      }
+      const platform = query.toLowerCase()
+      if (PLATFORMS.indexOf(platform) !== -1) {
+        const pool = games.filter(game => game.platform === platform)
+        if (pool.length === 0) return msg.reply(`no encontré juegos de "${query}" en el SuperMuseum`)
+        return msg.send(formatGame(msg.random(pool)))
+      }
+      const needle = query.toLowerCase()
+      const matches = games.filter(game => String(game.title || '').toLowerCase().includes(needle))
+      if (matches.length === 0) return msg.reply(`no encontré juegos para "${query}" en el SuperMuseum`)
+      const shown = matches.slice(0, MAX_RESULTS).map(formatGame).join('\n\n')
+      const extra = matches.length > MAX_RESULTS ? `\n\n…y ${matches.length - MAX_RESULTS} más` : ''
+      return msg.send(shown + extra)
+    })
+  })
+}
+
+module.exports.PLATFORMS = PLATFORMS
+module.exports._resetCache = function () {
+  cache = { games: null, fetchedAt: 0 }
+}

--- a/test/supermuseum.test.js
+++ b/test/supermuseum.test.js
@@ -1,0 +1,123 @@
+'use strict'
+
+require('coffeescript/register')
+const test = require('./helpers/ava')
+const Helper = require('hubot-test-helper')
+const nock = require('nock')
+
+const script = require('../scripts/supermuseum.js')
+const helper = new Helper('../scripts/supermuseum.js')
+
+const BASE = 'https://supermuseum.netlify.app'
+
+const snesGames = [
+  { title: 'The Legend of Zelda: A Link to the Past', platform: 'snes', developer: 'Nintendo', year: 1992, serial: 'SNS-ZL-USA' },
+  { title: 'Super Mario World', platform: 'snes', developer: 'Nintendo', year: 1990, serial: 'SNS-MW-USA' }
+]
+const arcadeGames = [
+  { title: 'The Legend of Zelda', platform: 'arcade', developer: 'Nintendo', year: 1987, serial: 'zelda_arc' }
+]
+
+function stubLibraries () {
+  script.PLATFORMS.forEach(platform => {
+    let body = []
+    if (platform === 'snes') body = snesGames
+    if (platform === 'arcade') body = arcadeGames
+    nock(BASE).persist().get(`/json/${platform}.json`).reply(200, body)
+  })
+}
+
+test.beforeEach(t => {
+  script._resetCache()
+  nock.cleanAll()
+  stubLibraries()
+  t.context.room = helper.createRoom({ httpd: false })
+})
+test.afterEach(t => {
+  t.context.room.destroy()
+})
+
+test.cb.serial('Comando vacío retorna un juego al azar', t => {
+  t.context.room.user.say('user', 'hubot supermuseum')
+  setTimeout(() => {
+    t.is(t.context.room.messages.length, 2)
+    t.is(t.context.room.messages[1][0], 'hubot')
+    t.true(/Super Nintendo|Arcade/.test(t.context.room.messages[1][1]))
+    t.true(/supermuseum\.netlify\.app\/\?play=/.test(t.context.room.messages[1][1]))
+    t.end()
+  }, 800)
+})
+
+test.cb.serial('Plataforma retorna un juego de esa plataforma', t => {
+  t.context.room.user.say('user', 'hubot supermuseum snes')
+  setTimeout(() => {
+    const reply = t.context.room.messages[1][1]
+    t.true(/Super Nintendo/.test(reply))
+    t.false(/\.\.\.y \d+ más/.test(reply))
+    t.end()
+  }, 800)
+})
+
+test.cb.serial('La plataforma no distingue mayúsculas', t => {
+  t.context.room.user.say('user', 'hubot supermuseum SNES')
+  setTimeout(() => {
+    t.true(/Super Nintendo/.test(t.context.room.messages[1][1]))
+    t.end()
+  }, 800)
+})
+
+test.cb.serial('Texto lista todos los juegos coincidentes', t => {
+  t.context.room.user.say('user', 'hubot supermuseum zelda')
+  setTimeout(() => {
+    const reply = t.context.room.messages[1][1]
+    t.true(/A Link to the Past/.test(reply))
+    t.true(/arcade/.test(reply))
+    t.end()
+  }, 800)
+})
+
+test.cb.serial('Texto desconocido retorna mensaje de no encontrado', t => {
+  t.context.room.user.say('user', 'hubot supermuseum xyzzy')
+  setTimeout(() => {
+    t.deepEqual(t.context.room.messages, [
+      ['user', 'hubot supermuseum xyzzy'],
+      ['hubot', '@user no encontré juegos para "xyzzy" en el SuperMuseum']
+    ])
+    t.end()
+  }, 800)
+})
+
+test.cb.serial('Lista larga se corta en 10 con coletilla', t => {
+  nock.cleanAll()
+  const many = []
+  for (let i = 1; i <= 12; i++) {
+    many.push({ title: `Zelda Test ${i}`, platform: 'snes', developer: 'Nintendo', year: 1992, serial: `SNS-ZT-${i}` })
+  }
+  script.PLATFORMS.forEach(platform => {
+    nock(BASE).persist().get(`/json/${platform}.json`).reply(200, platform === 'snes' ? many : [])
+  })
+  t.context.room.user.say('user', 'hubot supermuseum zelda test')
+  setTimeout(() => {
+    const reply = t.context.room.messages[1][1]
+    t.true(/Zelda Test 1/.test(reply))
+    t.true(/Zelda Test 10/.test(reply))
+    t.false(/Zelda Test 11/.test(reply))
+    t.true(/…y 2 más/.test(reply))
+    t.end()
+  }, 800)
+})
+
+test.cb.serial('Error del servidor retorna mensaje de error', t => {
+  nock.cleanAll()
+  script.PLATFORMS.forEach(platform => {
+    nock(BASE).get(`/json/${platform}.json`).reply(500)
+  })
+  t.context.room.user.say('user', 'hubot supermuseum')
+  setTimeout(() => {
+    t.deepEqual(t.context.room.messages[1], [
+      'hubot',
+      '@user ocurrió un error buscando en el SuperMuseum, intenta de nuevo más tarde'
+    ])
+    t.end()
+  }, 800)
+})


### PR DESCRIPTION

Recomienda juegos del SuperMuseum al azar, por plataforma o por texto

Agrega el comando `huemul supermuseum` con tres modos: juego al azar de todas las bibliotecas, juego al azar de una plataforma (`huemul supermuseum snes`) y búsqueda por título (`huemul supermuseum zelda`, hasta 10 resultados con deep link al museo).

Los JSON se leen en vivo desde supermuseum.netlify.app con caché de 24h y UA honesto `huemul-hubot` (allowlisteado en el museo). Sin dependencias nuevas. 7 tests con nock: `npx ava test/supermuseum.test.js`.

Para probar: `huemul supermuseum zelda`

cc @gmq para review 🙏